### PR TITLE
Add CI workflow for Ant build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '17'
+      - run: ant jar


### PR DESCRIPTION
## Summary
- add CI workflow to build plugin with Ant jar using Java 17

## Testing
- `ant jar` *(command not found: ant)*
- `apt-get update` *(failed to fetch repositories: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68926495a0cc8332bc424ab2b8db5929