### PR TITLE
Fix attribute listing to use registry keys

### DIFF
--- a/src/me/hammerle/mp/snuviscript/commands/ItemCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ItemCommands.java
@@ -114,7 +114,13 @@ public class ItemCommands {
         });
         MundusPlugin.scriptManager.registerFunction("item.getallattributes", (sc, in) -> {
             return Registry.ATTRIBUTE.stream()
-                    .map(f -> "minecraft:" + f.toString().toLowerCase())
+                    .map(attribute -> {
+                        NamespacedKey key = Registry.ATTRIBUTE.getKey(attribute);
+                        if(key != null) {
+                            return key.toString();
+                        }
+                        return "minecraft:" + attribute.toString().toLowerCase();
+                    })
                     .sorted()
                     .collect(Collectors.toList());
         });


### PR DESCRIPTION
### Motivation

- Ensure the `item.getallattributes` function returns proper namespaced registry keys instead of a legacy lowercased type string.
- Improve compatibility with attributes that have an explicit `NamespacedKey` in `Registry.ATTRIBUTE`.
- Provide a safe fallback for attributes that do not expose a registry key to avoid breaking scripts expecting a namespaced identifier.

### Description

- Changed the mapping in `item.getallattributes` to call `Registry.ATTRIBUTE.getKey(attribute)` and use the returned `NamespacedKey` string when present.
- Added a fallback that returns `"minecraft:" + attribute.toString().toLowerCase()` when no registry key is available.
- Kept the existing `sorted()` and `collect(Collectors.toList())` behavior so the output ordering and type remain unchanged.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe251179883329db54967d4680f93)