### PR TITLE
Register WorldGuard flags during plugin load

### DIFF
--- a/src/me/hammerle/mp/MundusPlugin.java
+++ b/src/me/hammerle/mp/MundusPlugin.java
@@ -138,6 +138,11 @@ public class MundusPlugin extends JavaPlugin implements ISnuviScheduler {
     }
 
     @Override
+    public void onLoad() {
+        WorldGuardCommands.registerFlagsOnLoad();
+    }
+
+    @Override
     public void onEnable() {
         enabled = true;
         log("§40.0.1");

--- a/src/me/hammerle/mp/snuviscript/commands/WorldGuardCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/WorldGuardCommands.java
@@ -34,6 +34,10 @@ public class WorldGuardCommands {
     private static IntegerFlag idFlag;
     private static StringFlag nameFlag;
 
+    public static void registerFlagsOnLoad() {
+        registerFlags();
+    }
+
     public static void registerFunctions() {
         registerFlags();
         MundusPlugin.scriptManager.registerFunction("plot.get", (sc, in) -> {


### PR DESCRIPTION
### Motivation
- Prevent the `IllegalStateException: New flags cannot be registered at this time` error by registering WorldGuard flags before WorldGuard locks the registry during plugin enable.

### Description
- Add `WorldGuardCommands.registerFlagsOnLoad()` and call it from `MundusPlugin.onLoad()` so flags (`mp-flags`, `mp-id`, `mp-name`) are registered early via the existing `registerFlags()` path.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b8c42ecfc8332bf0d40e3170b96b3)