### PR TITLE
Add loc.ischunkloaded script helper

### DIFF
--- a/src/me/hammerle/mp/snuviscript/commands/LocationCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/LocationCommands.java
@@ -56,6 +56,8 @@ public class LocationCommands {
                 (sc, in) -> (double) ((Location) in[0].get(sc)).getPitch());
         MundusPlugin.scriptManager.registerFunction("loc.getworld",
                 (sc, in) -> ((Location) in[0].get(sc)).getWorld());
+        MundusPlugin.scriptManager.registerFunction("loc.ischunkloaded",
+                (sc, in) -> ((Location) in[0].get(sc)).isChunkLoaded());
         MundusPlugin.scriptManager.registerFunction("loc.distance",
                 (sc, in) -> ((Location) in[0].get(sc)).distance((Location) in[1].get(sc)));
         MundusPlugin.scriptManager.registerFunction("loc.mod",


### PR DESCRIPTION
### Motivation
- Provide script-level access to `Location#isChunkLoaded()` so scripts can check whether a location's chunk is currently loaded.

### Description
- Register a new script function `loc.ischunkloaded` that returns the result of `Location.isChunkLoaded()` for the supplied `Location`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be6bb9b2083328604228d7a4d95cf)