### PR TITLE
Add dialog commands for scripts

### DIFF
--- a/src/me/hammerle/mp/MundusPlugin.java
+++ b/src/me/hammerle/mp/MundusPlugin.java
@@ -133,6 +133,7 @@ public class MundusPlugin extends JavaPlugin implements ISnuviScheduler {
         EnchantmentCommands.registerFunctions();
         ItemEntityCommands.registerFunctions();
         BossBarCommands.registerFunctions();
+        DialogCommands.registerFunctions();
         Commands.registerFunctions();
         LuckPermsCommands.registerFunctions();
     }

--- a/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
@@ -1,0 +1,320 @@
+package me.hammerle.mp.snuviscript.commands;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.entity.Player;
+import me.hammerle.mp.MundusPlugin;
+import net.kyori.adventure.text.Component;
+
+public class DialogCommands {
+    private static final String[] DIALOG_CLASSES = {
+            "io.papermc.paper.dialog.Dialog",
+            "net.kyori.adventure.dialog.Dialog"
+    };
+    private static final String[] BUTTON_CLASSES = {
+            "io.papermc.paper.dialog.DialogButton",
+            "net.kyori.adventure.dialog.DialogButton"
+    };
+    private static final String[] ACTION_CLASSES = {
+            "io.papermc.paper.dialog.DialogAction",
+            "io.papermc.paper.dialog.DialogButtonAction",
+            "net.kyori.adventure.dialog.DialogAction",
+            "net.kyori.adventure.dialog.DialogButtonAction"
+    };
+
+    public static void registerFunctions() {
+        MundusPlugin.scriptManager.registerFunction("dialog.new",
+                (sc, in) -> new DialogSpec((Component) in[0].get(sc),
+                        (Component) in[1].get(sc)));
+        MundusPlugin.scriptManager.registerConsumer("dialog.settitle", (sc, in) -> {
+            ((DialogSpec) in[0].get(sc)).setTitle((Component) in[1].get(sc));
+        });
+        MundusPlugin.scriptManager.registerConsumer("dialog.setbody", (sc, in) -> {
+            ((DialogSpec) in[0].get(sc)).setBody((Component) in[1].get(sc));
+        });
+        MundusPlugin.scriptManager.registerConsumer("dialog.addbutton", (sc, in) -> {
+            DialogSpec dialog = (DialogSpec) in[0].get(sc);
+            Component label = (Component) in[1].get(sc);
+            String actionType = in[2].getString(sc);
+            String actionValue = in[3].getString(sc);
+            dialog.addButton(new ButtonSpec(label, actionType, actionValue));
+        });
+        MundusPlugin.scriptManager.registerConsumer("dialog.show", (sc, in) -> {
+            Object dialog = in[0].get(sc);
+            Player player = (Player) in[1].get(sc);
+            showDialog(player, dialog);
+        });
+    }
+
+    private static void showDialog(Player player, Object dialog) {
+        if(dialog == null) {
+            return;
+        }
+        if(dialog instanceof DialogSpec) {
+            DialogSpec spec = (DialogSpec) dialog;
+            Object built = spec.buildDialog();
+            if(built != null && tryShow(player, built)) {
+                return;
+            }
+            sendFallback(player, spec);
+            return;
+        }
+        if(!tryShow(player, dialog)) {
+            player.sendMessage(Component.text(dialog.toString()));
+        }
+    }
+
+    private static boolean tryShow(Player player, Object dialog) {
+        for(Method method : player.getClass().getMethods()) {
+            if(!method.getName().equals("showDialog") || method.getParameterCount() != 1) {
+                continue;
+            }
+            Class<?> param = method.getParameterTypes()[0];
+            if(!param.isInstance(dialog)) {
+                continue;
+            }
+            try {
+                method.invoke(player, dialog);
+                return true;
+            } catch(Exception ex) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static void sendFallback(Player player, DialogSpec spec) {
+        if(spec.title != null) {
+            player.sendMessage(spec.title);
+        }
+        if(spec.body != null) {
+            player.sendMessage(spec.body);
+        }
+        for(ButtonSpec button : spec.buttons) {
+            Component line = Component.text("[")
+                    .append(button.label == null ? Component.text("?") : button.label)
+                    .append(Component.text("] "))
+                    .append(Component.text(button.actionType))
+                    .append(Component.text(": "))
+                    .append(Component.text(button.actionValue));
+            player.sendMessage(line);
+        }
+    }
+
+    private static Class<?> firstClass(String[] names) {
+        for(String name : names) {
+            try {
+                return Class.forName(name);
+            } catch(ClassNotFoundException ex) {
+            }
+        }
+        return null;
+    }
+
+    private static Object buildAction(String actionType, String actionValue) {
+        Class<?> actionClass = firstClass(ACTION_CLASSES);
+        if(actionClass == null) {
+            return null;
+        }
+        String normalized = actionType == null ? "" : actionType.toLowerCase();
+        if(normalized.isEmpty() || normalized.equals("none")) {
+            return invokeStatic(actionClass, "none");
+        }
+        if(normalized.equals("command") || normalized.equals("run")) {
+            return invokeStatic(actionClass, "runCommand", String.class, actionValue);
+        }
+        if(normalized.equals("suggest")) {
+            return invokeStatic(actionClass, "suggestCommand", String.class, actionValue);
+        }
+        if(normalized.equals("url") || normalized.equals("link")) {
+            return invokeStatic(actionClass, "openUrl", String.class, actionValue);
+        }
+        if(normalized.equals("clipboard") || normalized.equals("copy")) {
+            return invokeStatic(actionClass, "copyToClipboard", String.class, actionValue);
+        }
+        return null;
+    }
+
+    private static Object buildButton(ButtonSpec spec) {
+        Class<?> buttonClass = firstClass(BUTTON_CLASSES);
+        if(buttonClass == null) {
+            return null;
+        }
+        Object action = buildAction(spec.actionType, spec.actionValue);
+        Object button = invokeStatic(buttonClass, "of", Component.class, spec.label);
+        if(button == null && action != null) {
+            button = invokeStatic(buttonClass, "of", Component.class, action.getClass(),
+                    spec.label, action);
+        }
+        if(button == null) {
+            button = invokeStatic(buttonClass, "create", Component.class, spec.label);
+        }
+        if(button == null) {
+            Object builder = invokeStatic(buttonClass, "builder", Component.class, spec.label);
+            if(builder == null) {
+                builder = invokeStatic(buttonClass, "builder");
+            }
+            if(builder != null) {
+                invoke(builder, "label", Component.class, spec.label);
+                if(action != null) {
+                    invoke(builder, "action", action.getClass(), action);
+                }
+                button = invoke(builder, "build");
+            }
+        }
+        return button;
+    }
+
+    private static Object buildDialog(DialogSpec spec) {
+        Class<?> dialogClass = firstClass(DIALOG_CLASSES);
+        if(dialogClass == null) {
+            return null;
+        }
+        Object builder = invokeStatic(dialogClass, "builder", Component.class, spec.title);
+        if(builder == null) {
+            builder = invokeStatic(dialogClass, "builder");
+        }
+        if(builder != null) {
+            invoke(builder, "title", Component.class, spec.title);
+            if(!invoke(builder, "body", Component.class, spec.body)) {
+                invoke(builder, "content", Component.class, spec.body);
+            }
+            for(ButtonSpec button : spec.buttons) {
+                Object builtButton = buildButton(button);
+                if(builtButton == null) {
+                    continue;
+                }
+                if(!invoke(builder, "button", builtButton.getClass(), builtButton)) {
+                    invoke(builder, "addButton", builtButton.getClass(), builtButton);
+                }
+            }
+            Object built = invoke(builder, "build");
+            if(built != null) {
+                return built;
+            }
+            return invoke(builder, "create");
+        }
+        Object dialog = invokeStatic(dialogClass, "create", Component.class, Component.class,
+                spec.title, spec.body);
+        if(dialog != null) {
+            return dialog;
+        }
+        return invokeStatic(dialogClass, "of", Component.class, Component.class, spec.title,
+                spec.body);
+    }
+
+    private static Object invokeStatic(Class<?> type, String name, Class<?> param,
+            Object arg) {
+        if(type == null) {
+            return null;
+        }
+        try {
+            return type.getMethod(name, param).invoke(null, arg);
+        } catch(Exception ex) {
+            return null;
+        }
+    }
+
+    private static Object invokeStatic(Class<?> type, String name) {
+        if(type == null) {
+            return null;
+        }
+        try {
+            return type.getMethod(name).invoke(null);
+        } catch(Exception ex) {
+            return null;
+        }
+    }
+
+    private static Object invokeStatic(Class<?> type, String name, Class<?> paramOne,
+            Class<?> paramTwo, Object argOne, Object argTwo) {
+        if(type == null) {
+            return null;
+        }
+        try {
+            return type.getMethod(name, paramOne, paramTwo).invoke(null, argOne, argTwo);
+        } catch(Exception ex) {
+            return null;
+        }
+    }
+
+    private static boolean invoke(Object target, String name, Class<?> param, Object arg) {
+        if(target == null || arg == null) {
+            return false;
+        }
+        try {
+            Method method = target.getClass().getMethod(name, param);
+            method.invoke(target, arg);
+            return true;
+        } catch(Exception ex) {
+            for(Method method : target.getClass().getMethods()) {
+                if(!method.getName().equals(name) || method.getParameterCount() != 1) {
+                    continue;
+                }
+                Class<?> parameter = method.getParameterTypes()[0];
+                if(!parameter.isInstance(arg)) {
+                    continue;
+                }
+                try {
+                    method.invoke(target, arg);
+                    return true;
+                } catch(Exception inner) {
+                    return false;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static Object invoke(Object target, String name) {
+        if(target == null) {
+            return null;
+        }
+        try {
+            Method method = target.getClass().getMethod(name);
+            return method.invoke(target);
+        } catch(Exception ex) {
+            return null;
+        }
+    }
+
+    private static class DialogSpec {
+        private Component title;
+        private Component body;
+        private final List<ButtonSpec> buttons = new ArrayList<>();
+
+        DialogSpec(Component title, Component body) {
+            this.title = title;
+            this.body = body;
+        }
+
+        void setTitle(Component title) {
+            this.title = title;
+        }
+
+        void setBody(Component body) {
+            this.body = body;
+        }
+
+        void addButton(ButtonSpec button) {
+            buttons.add(button);
+        }
+
+        Object buildDialog() {
+            return DialogCommands.buildDialog(this);
+        }
+    }
+
+    private static class ButtonSpec {
+        private final Component label;
+        private final String actionType;
+        private final String actionValue;
+
+        ButtonSpec(Component label, String actionType, String actionValue) {
+            this.label = label;
+            this.actionType = actionType == null ? "" : actionType;
+            this.actionValue = actionValue == null ? "" : actionValue;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide scripting access to the Paper/Adventure dialog API so scripts can create and show interactive dialogs to players.
- Ensure compatibility across different upstream API packages/versions and gracefully degrade to chat output when dialog APIs are not present.

### Description

- Add `src/me/hammerle/mp/snuviscript/commands/DialogCommands.java` which implements a reflective dialog builder that detects `io.papermc.paper.dialog.*` and `net.kyori.adventure.dialog.*` types and can construct dialogs, buttons and actions at runtime.
- Expose scripting functions `dialog.new`, `dialog.settitle`, `dialog.setbody`, `dialog.addbutton` and `dialog.show` via the `ScriptManager` so scripts can build and display dialogs.
- Implement action mapping (run/suggest/URL/clipboard/none) and multiple builder invocation fallbacks, plus reflection helper methods (`invokeStatic`, `invoke`) to accommodate differing API signatures.
- Provide a chat fallback (`sendFallback`) that prints title/body and button descriptors when no dialog API or show method is available.
- Register the new dialog commands during plugin initialization by calling `DialogCommands.registerFunctions()` from `MundusPlugin`.

### Testing

- No automated tests were executed for this change (no compile/test run in the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c0e302160833292dfc05643712f92)