### PR TITLE
Enable dialog actions and custom click handling

### DIFF
--- a/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
@@ -82,13 +82,14 @@ public class DialogCommands {
 
         Dialog build() {
             return Dialog.create(builder -> {
-                builder.empty()
+                var dialogBuilder = builder.empty()
                         .base(DialogBase.builder(title)
                                 .body(List.of(DialogBody.plainMessage(body)))
                                 .build());
                 if(!buttons.isEmpty()) {
-                    builder.type(DialogType.multiAction(List.copyOf(buttons)));
+                    dialogBuilder.type(DialogType.multiAction(List.copyOf(buttons)));
                 }
+                dialogBuilder.build();
             });
         }
     }

--- a/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
@@ -2,10 +2,8 @@ package me.hammerle.mp.snuviscript.commands;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import org.bukkit.entity.Player;
 import io.papermc.paper.dialog.Dialog;
-import io.papermc.paper.dialog.DialogResponseView;
 import io.papermc.paper.registry.data.dialog.ActionButton;
 import io.papermc.paper.registry.data.dialog.DialogBase;
 import io.papermc.paper.registry.data.dialog.body.DialogBody;

--- a/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
@@ -87,9 +87,8 @@ public class DialogCommands {
                                 .body(List.of(DialogBody.plainMessage(body)))
                                 .build());
                 if(!buttons.isEmpty()) {
-                    dialogBuilder.type(DialogType.multiAction(List.copyOf(buttons)));
+                    dialogBuilder.type(DialogType.multiAction(List.copyOf(buttons)).build());
                 }
-                dialogBuilder.build();
             });
         }
     }

--- a/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
@@ -12,6 +12,7 @@ import io.papermc.paper.registry.data.dialog.body.DialogBody;
 import io.papermc.paper.registry.data.dialog.action.DialogAction;
 import io.papermc.paper.registry.data.dialog.type.DialogType;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.key.Key;
 import me.hammerle.mp.MundusPlugin;
 
 public class DialogCommands {
@@ -99,7 +100,7 @@ public class DialogCommands {
         }
         // customClick will later be captured with PlayerCustomClickEvent
         if("custom".equalsIgnoreCase(type)) {
-            return DialogAction.customClick(value, null);
+            return DialogAction.customClick(Key.key(value), null);
         }
         // staticAction allows basic built-in click behavior
         return DialogAction.staticAction(null);

--- a/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
@@ -80,13 +80,15 @@ public class DialogCommands {
         }
 
         Dialog build() {
-            return Dialog.create(builder -> builder
-                    .empty()
-                    .base(DialogBase.builder(title)
-                            .body(List.of(DialogBody.plainMessage(body)))
-                            .build())
-            //.type(DialogType.multiAction(buttons))
-            );
+            return Dialog.create(builder -> {
+                builder.empty()
+                        .base(DialogBase.builder(title)
+                                .body(List.of(DialogBody.plainMessage(body)))
+                                .build());
+                if(!buttons.isEmpty()) {
+                    builder.type(DialogType.multiAction(List.copyOf(buttons)));
+                }
+            });
         }
     }
 
@@ -96,9 +98,9 @@ public class DialogCommands {
             return DialogAction.commandTemplate(value);
         }
         // customClick will later be captured with PlayerCustomClickEvent
-        //if("custom".equalsIgnoreCase(type)) {
-        //    return DialogAction.customClick(value, null);
-        //}
+        if("custom".equalsIgnoreCase(type)) {
+            return DialogAction.customClick(value, null);
+        }
         // staticAction allows basic built-in click behavior
         return DialogAction.staticAction(null);
     }


### PR DESCRIPTION
### Motivation
- Dialogs built by `DialogBuilderSpec` previously always omitted action buttons and commented out custom click behavior, preventing interactive multi-action dialogs from being shown.
- The change intends to activate multi-action dialogs when buttons are provided and enable custom click actions for scripted buttons.

### Description
- Update `DialogBuilderSpec.build()` to use a block-style lambda so the builder can conditionally call `builder.type(...)` when `buttons` is not empty.
- Set the dialog type to `DialogType.multiAction(List.copyOf(buttons))` when there are buttons to include actionable buttons in the rendered dialog.
- Restore handling of the `custom` action type so `createAction(...)` returns `DialogAction.customClick(value, null)` for `"custom"` action types.
- Preserve the existing base/body assembly using `DialogBase.builder(title)` and `DialogBody.plainMessage(body)`.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cc427c6b88332967fdda77f107f6c)