### PR TITLE
Add dialog input helpers and reflective builders for Paper dialogs

### DIFF
--- a/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DialogCommands.java
@@ -6,6 +6,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -49,6 +51,96 @@ public class DialogCommands {
             spec.addButton(label, actionType, actionValue);
         });
 
+        MundusPlugin.scriptManager.registerConsumer("dialog.addinput", (sc, in) -> {
+            DialogBuilderSpec spec = (DialogBuilderSpec) in[0].get(sc);
+            spec.addInput(in[1].get(sc));
+        });
+
+        MundusPlugin.scriptManager.registerFunction("dialog.input.bool", (sc, in) -> {
+            Component label = (Component) in[0].get(sc);
+            String key = in[1].getString(sc);
+            boolean initial = in.length > 2 && in[2].getBoolean(sc);
+            return createBoolInput(label, key, initial);
+        });
+
+        MundusPlugin.scriptManager.registerFunction("dialog.input.text", (sc, in) -> {
+            Component label = (Component) in[0].get(sc);
+            String key = in[1].getString(sc);
+            String initial = in.length > 2 ? in[2].getString(sc) : "";
+            int maxLength = in.length > 3 ? in[3].getInt(sc) : 100;
+            return createTextInput(label, key, initial, maxLength);
+        });
+
+        MundusPlugin.scriptManager.registerFunction("dialog.input.numberrange", (sc, in) -> {
+            Component label = (Component) in[0].get(sc);
+            String key = in[1].getString(sc);
+            double min = in[2].getDouble(sc);
+            double max = in[3].getDouble(sc);
+            double step = in[4].getDouble(sc);
+            double initial = in[5].getDouble(sc);
+            return createNumberRangeInput(label, key, min, max, step, initial);
+        });
+
+        MundusPlugin.scriptManager.registerFunction("dialog.input.singleoption", (sc, in) -> {
+            Component label = (Component) in[0].get(sc);
+            String key = in[1].getString(sc);
+            List<DialogOptionSpec> options = (List<DialogOptionSpec>) in[2].get(sc);
+            int initialIndex = in.length > 3 ? in[3].getInt(sc) : 0;
+            return createSingleOptionInput(label, key, options, initialIndex);
+        });
+
+        MundusPlugin.scriptManager.registerFunction("dialog.option", (sc, in) -> {
+            Component label = (Component) in[0].get(sc);
+            String value = in.length > 1 ? in[1].getString(sc) : "";
+            return new DialogOptionSpec(label, value);
+        });
+
+        MundusPlugin.scriptManager.registerFunction("dialog.optionlist.new", (sc, in) -> {
+            return new ArrayList<DialogOptionSpec>();
+        });
+
+        MundusPlugin.scriptManager.registerConsumer("dialog.optionlist.add", (sc, in) -> {
+            List<DialogOptionSpec> list = (List<DialogOptionSpec>) in[0].get(sc);
+            list.add((DialogOptionSpec) in[1].get(sc));
+        });
+
+        MundusPlugin.scriptManager.registerConsumer("dialog.addinput.bool", (sc, in) -> {
+            DialogBuilderSpec spec = (DialogBuilderSpec) in[0].get(sc);
+            Component label = (Component) in[1].get(sc);
+            String key = in[2].getString(sc);
+            boolean initial = in.length > 3 && in[3].getBoolean(sc);
+            spec.addBoolInput(label, key, initial);
+        });
+
+        MundusPlugin.scriptManager.registerConsumer("dialog.addinput.text", (sc, in) -> {
+            DialogBuilderSpec spec = (DialogBuilderSpec) in[0].get(sc);
+            Component label = (Component) in[1].get(sc);
+            String key = in[2].getString(sc);
+            String initial = in.length > 3 ? in[3].getString(sc) : "";
+            int maxLength = in.length > 4 ? in[4].getInt(sc) : 100;
+            spec.addTextInput(label, key, initial, maxLength);
+        });
+
+        MundusPlugin.scriptManager.registerConsumer("dialog.addinput.numberrange", (sc, in) -> {
+            DialogBuilderSpec spec = (DialogBuilderSpec) in[0].get(sc);
+            Component label = (Component) in[1].get(sc);
+            String key = in[2].getString(sc);
+            double min = in[3].getDouble(sc);
+            double max = in[4].getDouble(sc);
+            double step = in[5].getDouble(sc);
+            double initial = in[6].getDouble(sc);
+            spec.addNumberRangeInput(label, key, min, max, step, initial);
+        });
+
+        MundusPlugin.scriptManager.registerConsumer("dialog.addinput.singleoption", (sc, in) -> {
+            DialogBuilderSpec spec = (DialogBuilderSpec) in[0].get(sc);
+            Component label = (Component) in[1].get(sc);
+            String key = in[2].getString(sc);
+            List<DialogOptionSpec> options = (List<DialogOptionSpec>) in[3].get(sc);
+            int initialIndex = in.length > 4 ? in[4].getInt(sc) : 0;
+            spec.addSingleOptionInput(label, key, options, initialIndex);
+        });
+
         MundusPlugin.scriptManager.registerConsumer("dialog.show", (sc, in) -> {
             DialogBuilderSpec spec = (DialogBuilderSpec) in[0].get(sc);
             Player player = (Player) in[1].get(sc);
@@ -69,6 +161,7 @@ public class DialogCommands {
         private Component title;
         private Component body;
         private final List<ActionButton> buttons = new ArrayList<>();
+        private final List<Object> inputs = new ArrayList<>();
 
         DialogBuilderSpec(Component title, Component body) {
             this.title = title;
@@ -91,16 +184,51 @@ public class DialogCommands {
             buttons.add(button);
         }
 
+        void addInput(Object input) {
+            if(input == null) {
+                return;
+            }
+            inputs.add(input);
+        }
+
+        void addBoolInput(Component label, String key, boolean initial) {
+            addInput(createBoolInput(label, key, initial));
+        }
+
+        void addTextInput(Component label, String key, String initial, int maxLength) {
+            addInput(createTextInput(label, key, initial, maxLength));
+        }
+
+        void addNumberRangeInput(Component label, String key, double min, double max, double step,
+                double initial) {
+            addInput(createNumberRangeInput(label, key, min, max, step, initial));
+        }
+
+        void addSingleOptionInput(Component label, String key, List<DialogOptionSpec> options,
+                int initialIndex) {
+            addInput(createSingleOptionInput(label, key, options, initialIndex));
+        }
+
         Dialog build() {
             return Dialog.create(builder -> {
-                var dialogBuilder = builder.empty()
-                        .base(DialogBase.builder(title)
-                                .body(List.of(DialogBody.plainMessage(body)))
-                                .build());
+                var baseBuilder = DialogBase.builder(title)
+                        .body(List.of(DialogBody.plainMessage(body)));
+                applyInputs(baseBuilder, inputs);
+                var dialogBuilder = builder.empty().base(baseBuilder.build());
                 if(!buttons.isEmpty()) {
                     dialogBuilder.type(DialogType.multiAction(List.copyOf(buttons)).build());
                 }
             });
+        }
+    }
+
+    private static class DialogOptionSpec {
+        private final Component label;
+        private final String value;
+
+        DialogOptionSpec(Component label, String value) {
+            this.label = label;
+            this.value = value;
         }
     }
 
@@ -156,6 +284,229 @@ public class DialogCommands {
         Key key = Key.key("mundus", "custom/" + UUID.randomUUID());
         CUSTOM_ACTIONS.put(key, value);
         return key;
+    }
+
+    private static Object createBoolInput(Component label, String key, boolean initial) {
+        Key inputKey = createInputKey(key);
+        return createDialogInput("bool",
+                new Object[] {inputKey, label, initial},
+                new Object[] {label, initial},
+                new Object[] {inputKey, label});
+    }
+
+    private static Object createTextInput(Component label, String key, String initial,
+            int maxLength) {
+        Key inputKey = createInputKey(key);
+        return createDialogInput("text",
+                new Object[] {inputKey, label, initial, maxLength},
+                new Object[] {label, initial, maxLength},
+                new Object[] {inputKey, label, initial},
+                new Object[] {label, initial});
+    }
+
+    private static Object createNumberRangeInput(Component label, String key, double min,
+            double max, double step, double initial) {
+        Key inputKey = createInputKey(key);
+        int minInt = (int) min;
+        int maxInt = (int) max;
+        int stepInt = (int) step;
+        int initialInt = (int) initial;
+        return createDialogInput("numberRange",
+                new Object[] {inputKey, label, min, max, step, initial},
+                new Object[] {label, min, max, step, initial},
+                new Object[] {inputKey, label, minInt, maxInt, stepInt, initialInt},
+                new Object[] {label, minInt, maxInt, stepInt, initialInt},
+                new Object[] {inputKey, label, min, max},
+                new Object[] {label, min, max});
+    }
+
+    private static Object createSingleOptionInput(Component label, String key,
+            List<DialogOptionSpec> options, int initialIndex) {
+        Key inputKey = createInputKey(key);
+        List<Object> optionList = new ArrayList<>();
+        if(options != null) {
+            for(DialogOptionSpec option : options) {
+                Object built = createDialogOption(option);
+                if(built != null) {
+                    optionList.add(built);
+                }
+            }
+        }
+        return createDialogInput("singleOption",
+                new Object[] {inputKey, label, optionList, initialIndex},
+                new Object[] {label, optionList, initialIndex},
+                new Object[] {inputKey, label, optionList},
+                new Object[] {label, optionList});
+    }
+
+    private static Object createDialogOption(DialogOptionSpec option) {
+        if(option == null) {
+            return null;
+        }
+        Class<?> dialogInputClass = getDialogInputClass();
+        Object created = invokeStatic(dialogInputClass, "option",
+                new Object[] {option.label, option.value});
+        if(created != null) {
+            return created;
+        }
+        Class<?> optionClass = getDialogOptionClass();
+        created = invokeStatic(optionClass, "of", new Object[] {option.label, option.value});
+        if(created != null) {
+            return created;
+        }
+        Object builder = invokeStatic(optionClass, "builder", new Object[] {option.label});
+        if(builder != null) {
+            invokeInstance(builder, "value", new Object[] {option.value});
+            return invokeInstance(builder, "build", new Object[0]);
+        }
+        return null;
+    }
+
+    private static Object createDialogInput(String method, Object[]... candidates) {
+        Class<?> dialogInputClass = getDialogInputClass();
+        if(dialogInputClass == null) {
+            return null;
+        }
+        for(Object[] args : candidates) {
+            Object created = invokeStatic(dialogInputClass, method, args);
+            if(created != null) {
+                return created;
+            }
+        }
+        return null;
+    }
+
+    private static void applyInputs(Object baseBuilder, List<Object> inputs) {
+        if(inputs == null || inputs.isEmpty() || baseBuilder == null) {
+            return;
+        }
+        if(invokeInstance(baseBuilder, "inputs", new Object[] {List.copyOf(inputs)}) != null) {
+            return;
+        }
+        for(Object input : inputs) {
+            if(invokeInstance(baseBuilder, "input", new Object[] {input}) == null) {
+                break;
+            }
+        }
+    }
+
+    private static Key createInputKey(String value) {
+        if(value != null && !value.isBlank()) {
+            try {
+                return Key.key(value);
+            } catch(RuntimeException ex) {
+                // fall through to generated key
+            }
+        }
+        return Key.key("mundus", "input/" + UUID.randomUUID());
+    }
+
+    private static Class<?> getDialogInputClass() {
+        try {
+            return Class.forName("io.papermc.paper.registry.data.dialog.input.DialogInput");
+        } catch(ClassNotFoundException ex) {
+            return null;
+        }
+    }
+
+    private static Class<?> getDialogOptionClass() {
+        try {
+            return Class.forName(
+                    "io.papermc.paper.registry.data.dialog.input.DialogInput$Option");
+        } catch(ClassNotFoundException ex) {
+            return null;
+        }
+    }
+
+    private static Object invokeStatic(Class<?> target, String methodName, Object[] args) {
+        if(target == null) {
+            return null;
+        }
+        for(Method method : target.getMethods()) {
+            if(!method.getName().equals(methodName)) {
+                continue;
+            }
+            if(!Modifier.isStatic(method.getModifiers())) {
+                continue;
+            }
+            if(!matches(method.getParameterTypes(), args)) {
+                continue;
+            }
+            try {
+                return method.invoke(null, args);
+            } catch(ReflectiveOperationException ex) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static Object invokeInstance(Object target, String methodName, Object[] args) {
+        if(target == null) {
+            return null;
+        }
+        for(Method method : target.getClass().getMethods()) {
+            if(!method.getName().equals(methodName)) {
+                continue;
+            }
+            if(!matches(method.getParameterTypes(), args)) {
+                continue;
+            }
+            try {
+                return method.invoke(target, args);
+            } catch(ReflectiveOperationException ex) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static boolean matches(Class<?>[] params, Object[] args) {
+        if(params.length != args.length) {
+            return false;
+        }
+        for(int i = 0; i < params.length; i++) {
+            if(!isCompatible(params[i], args[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isCompatible(Class<?> paramType, Object arg) {
+        if(arg == null) {
+            return !paramType.isPrimitive();
+        }
+        Class<?> wrapped = paramType.isPrimitive() ? wrapPrimitive(paramType) : paramType;
+        return wrapped.isInstance(arg);
+    }
+
+    private static Class<?> wrapPrimitive(Class<?> type) {
+        if(type == boolean.class) {
+            return Boolean.class;
+        }
+        if(type == int.class) {
+            return Integer.class;
+        }
+        if(type == long.class) {
+            return Long.class;
+        }
+        if(type == double.class) {
+            return Double.class;
+        }
+        if(type == float.class) {
+            return Float.class;
+        }
+        if(type == short.class) {
+            return Short.class;
+        }
+        if(type == byte.class) {
+            return Byte.class;
+        }
+        if(type == char.class) {
+            return Character.class;
+        }
+        return type;
     }
 
     private static void registerListener() {


### PR DESCRIPTION
### Motivation
- Expose dialog input functionality from Paper (bool/text/number-range/single-option) to the scripting API so scripts can build dialogs with inputs as described in the PaperMC dialogs docs.
- Add runtime-compatible code to construct dialog input and option objects across Paper API versions by calling into `DialogInput`/option factories reflectively when signatures vary.

### Description
- Added many script registrations (`dialog.input.*`, `dialog.option`, `dialog.optionlist.*`, `dialog.addinput.*`, and `dialog.addinput`) so scripts can create inputs/options and attach them to a `DialogBuilderSpec` using `MundusPlugin.scriptManager` functions/consumers.
- Extended `DialogBuilderSpec` to store inputs (`inputs` list) and apply them to the `DialogBase` builder when building a `Dialog` (`applyInputs` + call in `build`).
- Implemented input factory helpers (`createBoolInput`, `createTextInput`, `createNumberRangeInput`, `createSingleOptionInput`, `createDialogOption`) and an internal `DialogOptionSpec` wrapper to build option entries from script-provided labels/values.
- Introduced reflective helper utilities (`getDialogInputClass`, `getDialogOptionClass`, `invokeStatic`, `invokeInstance`, `matches`, `isCompatible`, `wrapPrimitive`) and `createInputKey` to allow calling different Paper API variants safely at runtime.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cea04b90883329bdf86890c3d4b45)