### PR TITLE
Expose AuraSkills to Snuvi scripts (SkillsCommands + registration)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,12 @@
 
     <target name="compile">
         <mkdir dir="build/classes"/>
-        <javac debug="true" includeantruntime="false" srcdir="src" destdir="build/classes" encoding="utf-8">
+        <javac debug="true"
+               includeantruntime="false"
+               srcdir="src"
+               destdir="build/classes"
+               encoding="utf-8"
+               release="21">
             <classpath>
                 <fileset dir="lib" includes="*.jar"/>
             </classpath>
@@ -13,12 +18,14 @@
     </target>
 
     <target name="jar" depends="compile">
-    <javac includeantruntime="false" srcdir="src" destdir="build/classes"/>
-    <jar destfile="build/MundusPlugin.jar" basedir="build/classes">
-        <fileset file="src/resources/plugin.yml"/>
-        <!-- Merge the contents of SnuviScriptRecoded.jar into your plugin jar -->
-        <zipgroupfileset dir="lib" includes="SnuviScriptRecoded.jar"/>
-    </jar>
-</target>
-
+        <javac includeantruntime="false"
+               srcdir="src"
+               destdir="build/classes"
+               release="21"/>
+        <jar destfile="build/MundusPlugin.jar" basedir="build/classes">
+            <fileset file="src/resources/plugin.yml"/>
+            <!-- Merge the contents of SnuviScriptRecoded.jar into your plugin jar -->
+            <zipgroupfileset dir="lib" includes="SnuviScriptRecoded.jar"/>
+        </jar>
+    </target>
 </project>

--- a/src/me/hammerle/mp/MundusPlugin.java
+++ b/src/me/hammerle/mp/MundusPlugin.java
@@ -135,6 +135,7 @@ public class MundusPlugin extends JavaPlugin implements ISnuviScheduler {
         BossBarCommands.registerFunctions();
         Commands.registerFunctions();
         LuckPermsCommands.registerFunctions();
+        SkillsCommands.registerFunctions();
     }
 
     @Override

--- a/src/me/hammerle/mp/snuviscript/commands/SkillsCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/SkillsCommands.java
@@ -284,45 +284,61 @@ public class SkillsCommands {
         if(skill != null && invokeFirstMatching(registry, REGISTER_METHOD_NAMES, skill) != null) {
             return;
         }
+        List<Object> keyCandidates = new ArrayList<>();
+        keyCandidates.add(key);
+        NamespacedKey namespacedKey = toNamespacedKey(key);
+        if(namespacedKey != null) {
+            keyCandidates.add(namespacedKey);
+        }
+        Key adventureKey = toAdventureKey(key);
+        if(adventureKey != null) {
+            keyCandidates.add(adventureKey);
+        }
         List<Object[]> candidates = new ArrayList<>();
-        candidates.add(new Object[] {key, displayName});
-        candidates.add(new Object[] {key, displayComponent});
-        if(icon != null) {
-            candidates.add(new Object[] {key, displayName, icon});
-            candidates.add(new Object[] {key, displayComponent, icon});
-        }
-        if(description != null) {
-            candidates.add(new Object[] {key, displayName, description});
-            candidates.add(new Object[] {key, displayComponent, description});
-        }
-        if(descriptionComponents != null) {
-            candidates.add(new Object[] {key, displayName, descriptionComponents});
-            candidates.add(new Object[] {key, displayComponent, descriptionComponents});
-        }
-        if(icon != null && description != null) {
-            candidates.add(new Object[] {key, displayName, icon, description});
-            candidates.add(new Object[] {key, displayComponent, icon, description});
-        }
-        if(icon != null && descriptionComponents != null) {
-            candidates.add(new Object[] {key, displayName, icon, descriptionComponents});
-            candidates.add(new Object[] {key, displayComponent, icon, descriptionComponents});
-        }
-        if(maxLevel != null) {
-            candidates.add(new Object[] {key, displayName, maxLevel});
-            candidates.add(new Object[] {key, displayComponent, maxLevel});
+        for(Object keyCandidate : keyCandidates) {
+            candidates.add(new Object[] {keyCandidate, displayName});
+            candidates.add(new Object[] {keyCandidate, displayComponent});
             if(icon != null) {
-                candidates.add(new Object[] {key, displayName, icon, maxLevel});
-                candidates.add(new Object[] {key, displayComponent, icon, maxLevel});
+                candidates.add(new Object[] {keyCandidate, displayName, icon});
+                candidates.add(new Object[] {keyCandidate, displayComponent, icon});
+            }
+            if(description != null) {
+                candidates.add(new Object[] {keyCandidate, displayName, description});
+                candidates.add(new Object[] {keyCandidate, displayComponent, description});
+            }
+            if(descriptionComponents != null) {
+                candidates.add(new Object[] {keyCandidate, displayName, descriptionComponents});
+                candidates.add(new Object[] {keyCandidate, displayComponent, descriptionComponents});
             }
             if(icon != null && description != null) {
-                candidates.add(new Object[] {key, displayName, icon, description, maxLevel});
-                candidates.add(new Object[] {key, displayComponent, icon, description, maxLevel});
+                candidates.add(new Object[] {keyCandidate, displayName, icon, description});
+                candidates.add(new Object[] {keyCandidate, displayComponent, icon, description});
             }
             if(icon != null && descriptionComponents != null) {
                 candidates.add(
-                        new Object[] {key, displayName, icon, descriptionComponents, maxLevel});
+                        new Object[] {keyCandidate, displayName, icon, descriptionComponents});
                 candidates.add(
-                        new Object[] {key, displayComponent, icon, descriptionComponents, maxLevel});
+                        new Object[] {keyCandidate, displayComponent, icon, descriptionComponents});
+            }
+            if(maxLevel != null) {
+                candidates.add(new Object[] {keyCandidate, displayName, maxLevel});
+                candidates.add(new Object[] {keyCandidate, displayComponent, maxLevel});
+                if(icon != null) {
+                    candidates.add(new Object[] {keyCandidate, displayName, icon, maxLevel});
+                    candidates.add(new Object[] {keyCandidate, displayComponent, icon, maxLevel});
+                }
+                if(icon != null && description != null) {
+                    candidates.add(new Object[] {keyCandidate, displayName, icon, description,
+                            maxLevel});
+                    candidates.add(new Object[] {keyCandidate, displayComponent, icon, description,
+                            maxLevel});
+                }
+                if(icon != null && descriptionComponents != null) {
+                    candidates.add(new Object[] {keyCandidate, displayName, icon,
+                            descriptionComponents, maxLevel});
+                    candidates.add(new Object[] {keyCandidate, displayComponent, icon,
+                            descriptionComponents, maxLevel});
+                }
             }
         }
         for(Object[] args : candidates) {

--- a/src/me/hammerle/mp/snuviscript/commands/SkillsCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/SkillsCommands.java
@@ -1,0 +1,549 @@
+package me.hammerle.mp.snuviscript.commands;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import me.hammerle.mp.MundusPlugin;
+import net.kyori.adventure.text.Component;
+
+public class SkillsCommands {
+    private static final String[] API_CLASS_NAMES = {
+            "com.archyx.auraskills.api.AuraSkills",
+            "com.archyx.auraskills.api.AuraSkillsApi",
+            "dev.aurelium.auraskills.api.AuraSkillsApi",
+            "dev.aurelium.auraskills.api.AuraSkills",
+            "com.auraskills.api.AuraSkillsApi",
+            "com.auraskills.api.AuraSkills"
+    };
+
+    private static final String[] CUSTOM_SKILL_CLASS_NAMES = {
+            "com.archyx.auraskills.api.skill.CustomSkill",
+            "dev.aurelium.auraskills.api.skill.CustomSkill",
+            "com.auraskills.api.skill.CustomSkill"
+    };
+
+    private static final String[] SKILL_CLASS_NAMES = {
+            "com.archyx.auraskills.api.skill.Skill",
+            "dev.aurelium.auraskills.api.skill.Skill",
+            "com.auraskills.api.skill.Skill"
+    };
+
+    private static final String[] REGISTRY_METHOD_NAMES = {
+            "getSkillRegistry",
+            "getSkills",
+            "getSkillManager"
+    };
+
+    private static final String[] REGISTER_METHOD_NAMES = {
+            "registerCustomSkill",
+            "registerSkill",
+            "register",
+            "addCustomSkill",
+            "addSkill"
+    };
+
+    private static final String[] GET_SKILL_METHOD_NAMES = {
+            "getSkill",
+            "getSkillByName",
+            "getSkillByKey"
+    };
+
+    private static final String[] GET_USER_MANAGER_METHOD_NAMES = {
+            "getUserManager",
+            "getPlayerManager",
+            "getUserRegistry"
+    };
+
+    private static final String[] GET_USER_METHOD_NAMES = {
+            "getUser",
+            "getPlayer",
+            "getUserData"
+    };
+
+    private static final String[] GET_LEVEL_METHOD_NAMES = {
+            "getSkillLevel",
+            "getLevel"
+    };
+
+    private static final String[] SET_LEVEL_METHOD_NAMES = {
+            "setSkillLevel",
+            "setLevel"
+    };
+
+    private static final String[] GET_XP_METHOD_NAMES = {
+            "getSkillXp",
+            "getXp",
+            "getExperience"
+    };
+
+    private static final String[] SET_XP_METHOD_NAMES = {
+            "setSkillXp",
+            "setXp",
+            "setExperience"
+    };
+
+    private static final String[] ADD_XP_METHOD_NAMES = {
+            "addSkillXp",
+            "addXp",
+            "addExperience"
+    };
+
+    public static void registerFunctions() {
+        MundusPlugin.scriptManager.registerConsumer("skills.custom.add", (sc, in) -> {
+            String key = in[0].getString(sc);
+            Object nameValue = in.length > 1 ? in[1].get(sc) : key;
+            String displayName = nameValue instanceof Component
+                    ? ((Component) nameValue).toString()
+                    : Objects.toString(nameValue, key);
+            Component displayComponent = nameValue instanceof Component
+                    ? (Component) nameValue
+                    : Component.text(displayName);
+            String iconName = in.length > 2 ? in[2].getString(sc) : null;
+            List<String> description = in.length > 3 ? toStringList(in[3].get(sc)) : null;
+            Integer maxLevel = in.length > 4 ? in[4].getInt(sc) : null;
+            registerCustomSkill(key, displayName, displayComponent, iconName, description, maxLevel);
+        });
+        MundusPlugin.scriptManager.registerFunction("skills.exists", (sc, in) -> {
+            return resolveSkill(getApi(), in[0].getString(sc)) != null;
+        });
+        MundusPlugin.scriptManager.registerFunction("skills.getlevel", (sc, in) -> {
+            Object api = getApi();
+            Object player = in[0].get(sc);
+            String skill = in[1].getString(sc);
+            Object result = invokeFirstMatching(api, GET_LEVEL_METHOD_NAMES, player, skill);
+            if(result != null) {
+                return toDouble(result);
+            }
+            UUID uuid = CommandUtils.getUUID(player);
+            result = invokeFirstMatching(api, GET_LEVEL_METHOD_NAMES, uuid, skill);
+            if(result != null) {
+                return toDouble(result);
+            }
+            Object user = resolveUser(api, player);
+            Object skillObj = resolveSkill(api, skill);
+            if(user == null || skillObj == null) {
+                return 0d;
+            }
+            result = invokeFirstMatching(user, GET_LEVEL_METHOD_NAMES, skillObj);
+            if(result == null) {
+                result = invokeFirstMatching(user, GET_LEVEL_METHOD_NAMES, skill);
+            }
+            return toDouble(result);
+        });
+        MundusPlugin.scriptManager.registerConsumer("skills.setlevel", (sc, in) -> {
+            Object api = getApi();
+            Object player = in[0].get(sc);
+            String skill = in[1].getString(sc);
+            int level = in[2].getInt(sc);
+            if(invokeFirstMatching(api, SET_LEVEL_METHOD_NAMES, player, skill, level) != null) {
+                return;
+            }
+            UUID uuid = CommandUtils.getUUID(player);
+            if(invokeFirstMatching(api, SET_LEVEL_METHOD_NAMES, uuid, skill, level) != null) {
+                return;
+            }
+            Object user = resolveUser(api, player);
+            Object skillObj = resolveSkill(api, skill);
+            if(user == null || skillObj == null) {
+                throw new IllegalStateException("AuraSkills user or skill not found");
+            }
+            if(invokeFirstMatching(user, SET_LEVEL_METHOD_NAMES, skillObj, level) != null) {
+                return;
+            }
+            if(invokeFirstMatching(user, SET_LEVEL_METHOD_NAMES, skill, level) != null) {
+                return;
+            }
+            throw new IllegalStateException("AuraSkills could not set skill level");
+        });
+        MundusPlugin.scriptManager.registerFunction("skills.getxp", (sc, in) -> {
+            Object api = getApi();
+            Object player = in[0].get(sc);
+            String skill = in[1].getString(sc);
+            Object result = invokeFirstMatching(api, GET_XP_METHOD_NAMES, player, skill);
+            if(result != null) {
+                return toDouble(result);
+            }
+            UUID uuid = CommandUtils.getUUID(player);
+            result = invokeFirstMatching(api, GET_XP_METHOD_NAMES, uuid, skill);
+            if(result != null) {
+                return toDouble(result);
+            }
+            Object user = resolveUser(api, player);
+            Object skillObj = resolveSkill(api, skill);
+            if(user == null || skillObj == null) {
+                return 0d;
+            }
+            result = invokeFirstMatching(user, GET_XP_METHOD_NAMES, skillObj);
+            if(result == null) {
+                result = invokeFirstMatching(user, GET_XP_METHOD_NAMES, skill);
+            }
+            return toDouble(result);
+        });
+        MundusPlugin.scriptManager.registerConsumer("skills.setxp", (sc, in) -> {
+            Object api = getApi();
+            Object player = in[0].get(sc);
+            String skill = in[1].getString(sc);
+            double amount = in[2].getDouble(sc);
+            if(invokeFirstMatching(api, SET_XP_METHOD_NAMES, player, skill, amount) != null) {
+                return;
+            }
+            UUID uuid = CommandUtils.getUUID(player);
+            if(invokeFirstMatching(api, SET_XP_METHOD_NAMES, uuid, skill, amount) != null) {
+                return;
+            }
+            Object user = resolveUser(api, player);
+            Object skillObj = resolveSkill(api, skill);
+            if(user == null || skillObj == null) {
+                throw new IllegalStateException("AuraSkills user or skill not found");
+            }
+            if(invokeFirstMatching(user, SET_XP_METHOD_NAMES, skillObj, amount) != null) {
+                return;
+            }
+            if(invokeFirstMatching(user, SET_XP_METHOD_NAMES, skill, amount) != null) {
+                return;
+            }
+            throw new IllegalStateException("AuraSkills could not set skill xp");
+        });
+        MundusPlugin.scriptManager.registerConsumer("skills.addxp", (sc, in) -> {
+            Object api = getApi();
+            Object player = in[0].get(sc);
+            String skill = in[1].getString(sc);
+            double amount = in[2].getDouble(sc);
+            if(invokeFirstMatching(api, ADD_XP_METHOD_NAMES, player, skill, amount) != null) {
+                return;
+            }
+            UUID uuid = CommandUtils.getUUID(player);
+            if(invokeFirstMatching(api, ADD_XP_METHOD_NAMES, uuid, skill, amount) != null) {
+                return;
+            }
+            Object user = resolveUser(api, player);
+            Object skillObj = resolveSkill(api, skill);
+            if(user == null || skillObj == null) {
+                throw new IllegalStateException("AuraSkills user or skill not found");
+            }
+            if(invokeFirstMatching(user, ADD_XP_METHOD_NAMES, skillObj, amount) != null) {
+                return;
+            }
+            if(invokeFirstMatching(user, ADD_XP_METHOD_NAMES, skill, amount) != null) {
+                return;
+            }
+            throw new IllegalStateException("AuraSkills could not add skill xp");
+        });
+    }
+
+    private static Object getApi() {
+        for(String className : API_CLASS_NAMES) {
+            try {
+                Class<?> apiClass = Class.forName(className);
+                Object api = invokeStatic(apiClass, "get", "getInstance", "getApi", "getAPI");
+                if(api != null) {
+                    return api;
+                }
+            } catch(ClassNotFoundException ex) {
+                // ignore
+            }
+        }
+        Plugin plugin = Bukkit.getPluginManager().getPlugin("AuraSkills");
+        if(plugin != null) {
+            Object api = invokeFirstMatching(plugin, new String[] {"getApi", "getAPI", "getAuraSkillsApi",
+                    "getAuraSkillsAPI"});
+            if(api != null) {
+                return api;
+            }
+        }
+        throw new IllegalStateException("AuraSkills API not available");
+    }
+
+    private static void registerCustomSkill(String key, String displayName, Component displayComponent,
+            String iconName, List<String> description, Integer maxLevel) {
+        Object api = getApi();
+        Object registry = resolveRegistry(api);
+        Object icon = iconName != null ? Material.matchMaterial(iconName) : null;
+        Object skill = createCustomSkill(key, displayName, displayComponent, icon, description,
+                maxLevel);
+        if(skill != null && invokeFirstMatching(registry, REGISTER_METHOD_NAMES, skill) != null) {
+            return;
+        }
+        List<Object[]> candidates = new ArrayList<>();
+        candidates.add(new Object[] {key, displayName});
+        candidates.add(new Object[] {key, displayComponent});
+        if(icon != null) {
+            candidates.add(new Object[] {key, displayName, icon});
+            candidates.add(new Object[] {key, displayComponent, icon});
+        }
+        if(description != null) {
+            candidates.add(new Object[] {key, displayName, description});
+            candidates.add(new Object[] {key, displayComponent, description});
+        }
+        if(icon != null && description != null) {
+            candidates.add(new Object[] {key, displayName, icon, description});
+            candidates.add(new Object[] {key, displayComponent, icon, description});
+        }
+        if(maxLevel != null) {
+            candidates.add(new Object[] {key, displayName, maxLevel});
+            candidates.add(new Object[] {key, displayComponent, maxLevel});
+            if(icon != null) {
+                candidates.add(new Object[] {key, displayName, icon, maxLevel});
+                candidates.add(new Object[] {key, displayComponent, icon, maxLevel});
+            }
+            if(icon != null && description != null) {
+                candidates.add(new Object[] {key, displayName, icon, description, maxLevel});
+                candidates.add(new Object[] {key, displayComponent, icon, description, maxLevel});
+            }
+        }
+        for(Object[] args : candidates) {
+            if(invokeFirstMatching(registry, REGISTER_METHOD_NAMES, args) != null) {
+                return;
+            }
+        }
+        throw new IllegalStateException("AuraSkills custom skill registration failed");
+    }
+
+    private static Object resolveRegistry(Object api) {
+        Object registry = invokeFirstMatching(api, REGISTRY_METHOD_NAMES);
+        return registry != null ? registry : api;
+    }
+
+    private static Object createCustomSkill(String key, String displayName, Component displayComponent,
+            Object icon, List<String> description, Integer maxLevel) {
+        Class<?> customSkillClass = loadClass(CUSTOM_SKILL_CLASS_NAMES);
+        if(customSkillClass == null) {
+            return null;
+        }
+        for(Constructor<?> ctor : customSkillClass.getConstructors()) {
+            Object[] args = buildArgsForConstructor(ctor.getParameterTypes(), key, displayName,
+                    displayComponent, icon, description, maxLevel);
+            if(args == null) {
+                continue;
+            }
+            try {
+                return ctor.newInstance(args);
+            } catch(Exception ex) {
+                // ignore and try next
+            }
+        }
+        return null;
+    }
+
+    private static Object resolveUser(Object api, Object player) {
+        Object user = invokeFirstMatching(api, GET_USER_METHOD_NAMES, player);
+        if(user != null) {
+            return user;
+        }
+        UUID uuid = CommandUtils.getUUID(player);
+        user = invokeFirstMatching(api, GET_USER_METHOD_NAMES, uuid);
+        if(user != null) {
+            return user;
+        }
+        Object manager = invokeFirstMatching(api, GET_USER_MANAGER_METHOD_NAMES);
+        if(manager == null) {
+            return null;
+        }
+        user = invokeFirstMatching(manager, GET_USER_METHOD_NAMES, player);
+        if(user != null) {
+            return user;
+        }
+        return invokeFirstMatching(manager, GET_USER_METHOD_NAMES, uuid);
+    }
+
+    private static Object resolveSkill(Object api, String skillName) {
+        Object registry = resolveRegistry(api);
+        Object skill = invokeFirstMatching(registry, GET_SKILL_METHOD_NAMES, skillName);
+        if(skill != null) {
+            return skill;
+        }
+        Object userSkill = invokeFirstMatching(api, GET_SKILL_METHOD_NAMES, skillName);
+        if(userSkill != null) {
+            return userSkill;
+        }
+        Class<?> skillClass = loadClass(SKILL_CLASS_NAMES);
+        if(skillClass != null) {
+            for(Object constant : skillClass.getEnumConstants()) {
+                if(constant != null && constant.toString().equalsIgnoreCase(skillName)) {
+                    return constant;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Object invokeStatic(Class<?> clazz, String... names) {
+        for(String name : names) {
+            try {
+                Method method = clazz.getMethod(name);
+                return method.invoke(null);
+            } catch(Exception ex) {
+                // ignore
+            }
+        }
+        return null;
+    }
+
+    private static Object invokeFirstMatching(Object target, String[] names, Object... args) {
+        if(target == null) {
+            return null;
+        }
+        List<String> nameList = Arrays.asList(names);
+        for(Method method : target.getClass().getMethods()) {
+            if(!nameList.contains(method.getName())) {
+                continue;
+            }
+            Object[] resolved = resolveArguments(method.getParameterTypes(), args);
+            if(resolved == null) {
+                continue;
+            }
+            try {
+                return method.invoke(target, resolved);
+            } catch(Exception ex) {
+                // ignore and try another
+            }
+        }
+        return null;
+    }
+
+    private static Object[] resolveArguments(Class<?>[] parameterTypes, Object[] args) {
+        if(parameterTypes.length != args.length) {
+            return null;
+        }
+        Object[] resolved = new Object[args.length];
+        for(int i = 0; i < parameterTypes.length; i++) {
+            Object value = coerceValue(parameterTypes[i], args[i]);
+            if(value == null && parameterTypes[i].isPrimitive()) {
+                return null;
+            }
+            if(value == null && args[i] != null) {
+                return null;
+            }
+            resolved[i] = value;
+        }
+        return resolved;
+    }
+
+    private static Object coerceValue(Class<?> type, Object value) {
+        if(value == null) {
+            return null;
+        }
+        if(type.isInstance(value)) {
+            return value;
+        }
+        if(type == double.class || type == Double.class) {
+            return value instanceof Number ? ((Number) value).doubleValue() : null;
+        }
+        if(type == int.class || type == Integer.class) {
+            return value instanceof Number ? ((Number) value).intValue() : null;
+        }
+        if(type == float.class || type == Float.class) {
+            return value instanceof Number ? ((Number) value).floatValue() : null;
+        }
+        if(type == long.class || type == Long.class) {
+            return value instanceof Number ? ((Number) value).longValue() : null;
+        }
+        if(type == String.class) {
+            return value.toString();
+        }
+        if(type == Component.class && value instanceof String) {
+            return Component.text((String) value);
+        }
+        if(type == UUID.class && value instanceof Player) {
+            return ((Player) value).getUniqueId();
+        }
+        if(type == Material.class && value instanceof String) {
+            return Material.matchMaterial((String) value);
+        }
+        return null;
+    }
+
+    private static Object[] buildArgsForConstructor(Class<?>[] parameterTypes, String key,
+            String displayName, Component displayComponent, Object icon, List<String> description,
+            Integer maxLevel) {
+        Object[] args = new Object[parameterTypes.length];
+        int stringCount = 0;
+        for(int i = 0; i < parameterTypes.length; i++) {
+            Class<?> param = parameterTypes[i];
+            Object value = null;
+            if(param == String.class) {
+                value = stringCount == 0 ? key : displayName;
+                stringCount++;
+            } else if(param == Component.class) {
+                value = displayComponent;
+            } else if(param.isInstance(icon)) {
+                value = icon;
+            } else if(description != null && param.isAssignableFrom(description.getClass())) {
+                value = description;
+            } else if(description != null && param.isAssignableFrom(List.class)) {
+                value = description;
+            } else if(maxLevel != null && (param == int.class || param == Integer.class)) {
+                value = maxLevel;
+            }
+            if(value == null && param.isPrimitive()) {
+                return null;
+            }
+            if(value == null && !param.isPrimitive()) {
+                return null;
+            }
+            args[i] = value;
+        }
+        return args;
+    }
+
+    private static Class<?> loadClass(String[] classNames) {
+        for(String name : classNames) {
+            try {
+                return Class.forName(name);
+            } catch(ClassNotFoundException ex) {
+                // ignore
+            }
+        }
+        return null;
+    }
+
+    private static List<String> toStringList(Object value) {
+        if(value == null) {
+            return null;
+        }
+        if(value instanceof List) {
+            List<?> list = (List<?>) value;
+            List<String> result = new ArrayList<>();
+            for(Object item : list) {
+                result.add(Objects.toString(item));
+            }
+            return result;
+        }
+        if(value instanceof Collection) {
+            Collection<?> collection = (Collection<?>) value;
+            List<String> result = new ArrayList<>();
+            for(Object item : collection) {
+                result.add(Objects.toString(item));
+            }
+            return result;
+        }
+        if(value instanceof Object[]) {
+            Object[] array = (Object[]) value;
+            List<String> result = new ArrayList<>();
+            for(Object item : array) {
+                result.add(Objects.toString(item));
+            }
+            return result;
+        }
+        return new ArrayList<>(List.of(Objects.toString(value)));
+    }
+
+    private static double toDouble(Object value) {
+        if(value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        if(value == null) {
+            return 0d;
+        }
+        return Double.parseDouble(value.toString());
+    }
+}

--- a/src/me/hammerle/mp/snuviscript/commands/SkillsCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/SkillsCommands.java
@@ -372,10 +372,13 @@ public class SkillsCommands {
             return userSkill;
         }
         Class<?> skillClass = loadClass(SKILL_CLASS_NAMES);
-        if(skillClass != null) {
-            for(Object constant : skillClass.getEnumConstants()) {
-                if(constant != null && constant.toString().equalsIgnoreCase(skillName)) {
-                    return constant;
+        if(skillClass != null && skillClass.isEnum()) {
+            Object[] constants = skillClass.getEnumConstants();
+            if(constants != null) {
+                for(Object constant : constants) {
+                    if(constant != null && constant.toString().equalsIgnoreCase(skillName)) {
+                        return constant;
+                    }
                 }
             }
         }

--- a/src/resources/plugin.yml
+++ b/src/resources/plugin.yml
@@ -1,7 +1,7 @@
 main: me.hammerle.mp.MundusPlugin
 name: MundusPlugin
-version: "1.0.6"
-api-version: "1.21.10"
+version: "1.0.7"
+api-version: "1.21.11"
 author: AUTHOR
 description: DESCRIPTION
 depend: [CommandAPI, Citizens, LuckPerms, WorldEdit, WorldGuard]


### PR DESCRIPTION
### Motivation
- Provide Snuvi script access to AuraSkills so scripts can query and manipulate skill levels/xp and register custom skills (e.g. Timber) without adding a compile-time dependency on AuraSkills.

### Description
- Added a new `SkillsCommands` class that registers script functions and consumers for `skills.custom.add`, `skills.exists`, `skills.getlevel`, `skills.setlevel`, `skills.getxp`, `skills.setxp`, and `skills.addxp` using reflection and multiple API fallbacks. 
- The integration performs dynamic API discovery with many candidate class and method names, user/skill resolution helpers, and constructor argument probing to support different AuraSkills versions and constructors. 
- Implemented argument coercion utilities (`coerceValue`, `resolveArguments`, `buildArgsForConstructor`, `toStringList`, etc.) to translate Snuvi script values into types expected by AuraSkills. 
- Registered `SkillsCommands.registerFunctions()` in `MundusPlugin.registerFunctions()` so the commands are available at plugin startup and applied a small fix to array handling in `toStringList` using `instanceof Object[]`.

### Testing
- No automated tests were executed for this change (none requested during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d17498ef88332913cf9d8898a8e87)