### PR TITLE
Register read.player return type directly in registerFunction

### DIFF
--- a/src/me/hammerle/mp/snuviscript/commands/ReadCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ReadCommands.java
@@ -20,7 +20,7 @@ public class ReadCommands {
                 }
             }
             return null;
-        });
+        }, "player");
         MundusPlugin.scriptManager.registerFunction("read.item", (sc, in) -> {
             String s = in[0].getString(sc);
             if(s.contains("minecraft:air")) {


### PR DESCRIPTION
### Motivation
- Co-locate the `read.player` return-type annotation with the function definition to avoid reflective fallbacks and keep static type information next to the implementation.

### Description
- Use the typed overload `registerFunction("read.player", ..., "player")` in `ReadCommands.java` so the function is registered with return type `player` directly.
- Remove the reflective function-return-type registration and its helper from `ScriptTypeRegistration.java`, leaving only the `entity` → `living` → `player` type hierarchy registration.

### Testing
- Reviewed the produced changes with `git diff` to confirm the `read.player` registration and removal of the reflective API (ok).
- Executed `javac -version` to validate Java tool availability (ok).
- Ran `ant compile` to attempt a full build which failed in this environment because `ant` is not installed (expected in-container limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997688e8a248332b4c59959dd92ea20)