### PR TITLE
Further refine script return metadata for item/entity/living commands

### DIFF
--- a/src/me/hammerle/mp/snuviscript/commands/ArmorStandCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ArmorStandCommands.java
@@ -7,25 +7,25 @@ import org.bukkit.util.EulerAngle;
 public class ArmorStandCommands {
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("as.getbodypose",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).getBodyPose());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).getBodyPose(), "object");
         MundusPlugin.scriptManager.registerFunction("as.getheadpose",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).getHeadPose());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).getHeadPose(), "object");
         MundusPlugin.scriptManager.registerFunction("as.getleftarmpose",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).getLeftArmPose());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).getLeftArmPose(), "object");
         MundusPlugin.scriptManager.registerFunction("as.getleftlegpose",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).getLeftLegPose());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).getLeftLegPose(), "object");
         MundusPlugin.scriptManager.registerFunction("as.getrightarmpose",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).getRightArmPose());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).getRightArmPose(), "object");
         MundusPlugin.scriptManager.registerFunction("as.getrightlegpose",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).getRightLegPose());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).getRightLegPose(), "object");
         MundusPlugin.scriptManager.registerFunction("as.hasarms",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).hasArms());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).hasArms(), "object");
         MundusPlugin.scriptManager.registerFunction("as.hasbaseplate",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).hasArms());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).hasArms(), "object");
         MundusPlugin.scriptManager.registerFunction("as.ismarker",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).isMarker());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).isMarker(), "object");
         MundusPlugin.scriptManager.registerFunction("as.issmall",
-                (sc, in) -> ((ArmorStand) in[0].get(sc)).isSmall());
+                (sc, in) -> ((ArmorStand) in[0].get(sc)).isSmall(), "object");
         MundusPlugin.scriptManager.registerConsumer("as.setarms",
                 (sc, in) -> ((ArmorStand) in[0].get(sc)).setArms(in[1].getBoolean(sc)));
         MundusPlugin.scriptManager.registerConsumer("as.setbaseplate",
@@ -57,18 +57,18 @@ public class ArmorStandCommands {
 
         MundusPlugin.scriptManager.registerFunction("euler.new",
                 (sc, in) -> new EulerAngle(in[0].getDouble(sc), in[1].getDouble(sc),
-                        in[2].getDouble(sc)));
+                        in[2].getDouble(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("euler.getx",
-                (sc, in) -> ((EulerAngle) in[0].get(sc)).getX());
+                (sc, in) -> ((EulerAngle) in[0].get(sc)).getX(), "object");
         MundusPlugin.scriptManager.registerFunction("euler.gety",
-                (sc, in) -> ((EulerAngle) in[0].get(sc)).getY());
+                (sc, in) -> ((EulerAngle) in[0].get(sc)).getY(), "object");
         MundusPlugin.scriptManager.registerFunction("euler.getz",
-                (sc, in) -> ((EulerAngle) in[0].get(sc)).getZ());
+                (sc, in) -> ((EulerAngle) in[0].get(sc)).getZ(), "object");
         MundusPlugin.scriptManager.registerFunction("euler.setx",
-                (sc, in) -> ((EulerAngle) in[0].get(sc)).setX(in[1].getDouble(sc)));
+                (sc, in) -> ((EulerAngle) in[0].get(sc)).setX(in[1].getDouble(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("euler.sety",
-                (sc, in) -> ((EulerAngle) in[0].get(sc)).setY(in[1].getDouble(sc)));
+                (sc, in) -> ((EulerAngle) in[0].get(sc)).setY(in[1].getDouble(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("euler.setz",
-                (sc, in) -> ((EulerAngle) in[0].get(sc)).setZ(in[1].getDouble(sc)));
+                (sc, in) -> ((EulerAngle) in[0].get(sc)).setZ(in[1].getDouble(sc)), "object");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/BlockCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/BlockCommands.java
@@ -33,17 +33,17 @@ public class BlockCommands {
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("block.gettag",
                 (sc, in) -> Bukkit.getTag(Tag.REGISTRY_BLOCKS,
-                        NamespacedKey.fromString(in[0].getString(sc)), Material.class));
+                        NamespacedKey.fromString(in[0].getString(sc)), Material.class), "object");
         MundusPlugin.scriptManager.registerFunction("block.hastag", (sc,
-                in) -> ((Tag<Material>) in[1].get(sc)).isTagged(((Block) in[0].get(sc)).getType()));
+                in) -> ((Tag<Material>) in[1].get(sc)).isTagged(((Block) in[0].get(sc)).getType()), "boolean");
         MundusPlugin.scriptManager.registerFunction("block.gettype",
-                (sc, in) -> ((Block) in[0].get(sc)).getType());
+                (sc, in) -> ((Block) in[0].get(sc)).getType(), "material");
         MundusPlugin.scriptManager.registerFunction("block.getlocation",
-                (sc, in) -> ((Block) in[0].get(sc)).getLocation());
+                (sc, in) -> ((Block) in[0].get(sc)).getLocation(), "location");
         MundusPlugin.scriptManager.registerFunction("block.get",
-                (sc, in) -> ((Location) in[0].get(sc)).getBlock());
+                (sc, in) -> ((Location) in[0].get(sc)).getBlock(), "block");
         MundusPlugin.scriptManager.registerFunction("block.getdata",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData());
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData(), "object");
         MundusPlugin.scriptManager.registerConsumer("block.clone", (sc, in) -> {
             Block fromBlock = (Block) in[0].get(sc);
             Location toLoc = (Location) in[1].get(sc);
@@ -103,7 +103,7 @@ public class BlockCommands {
             Sign sign = (Sign) b.getState();
             SignSide side = (SignSide) sign.getSide(Side.valueOf(in[1].getString(sc)));
             return side.line(in[2].getInt(sc));
-        });
+        }, "text");
         MundusPlugin.scriptManager.registerConsumer("block.signsetwaxed", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Sign sign = (Sign) b.getState();
@@ -116,7 +116,7 @@ public class BlockCommands {
                 return ((Container) state).getInventory();
             }
             return null;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("block.setopen", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Openable o = (Openable) b.getBlockData();
@@ -127,9 +127,9 @@ public class BlockCommands {
             Block b = (Block) in[0].get(sc);
             Openable o = (Openable) b.getBlockData();
             return o.isOpen();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("block.isopenable",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Openable);
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Openable, "boolean");
         MundusPlugin.scriptManager.registerConsumer("block.setdoorhinge", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Door o = (Door) b.getBlockData();
@@ -140,9 +140,9 @@ public class BlockCommands {
             Block b = (Block) in[0].get(sc);
             Door o = (Door) b.getBlockData();
             return o.getHinge().toString();
-        });
+        }, "string");
         MundusPlugin.scriptManager.registerFunction("block.isdoor",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Door);
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Door, "boolean");
         MundusPlugin.scriptManager.registerConsumer("block.setbisectedhalf", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Bisected o = (Bisected) b.getBlockData();
@@ -153,9 +153,9 @@ public class BlockCommands {
             Block b = (Block) in[0].get(sc);
             Bisected o = (Bisected) b.getBlockData();
             return o.getHalf().toString();
-        });
+        }, "string");
         MundusPlugin.scriptManager.registerFunction("block.isbisected",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Bisected);
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Bisected, "boolean");
         MundusPlugin.scriptManager.registerConsumer("block.setdirectionalface", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Directional o = (Directional) b.getBlockData();
@@ -166,14 +166,14 @@ public class BlockCommands {
             Block b = (Block) in[0].get(sc);
             Directional o = (Directional) b.getBlockData();
             return o.getFacing().toString();
-        });
+        }, "string");
         MundusPlugin.scriptManager.registerFunction("block.getdirectionalfaces", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Directional o = (Directional) b.getBlockData();
             return o.getFaces().stream().map(f -> f.toString()).collect(Collectors.toList());
-        });
+        }, "list");
         MundusPlugin.scriptManager.registerFunction("block.isdirectional",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Directional);
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Directional, "boolean");
         MundusPlugin.scriptManager.registerConsumer("block.setpersistent", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Leaves o = (Leaves) b.getBlockData();
@@ -184,11 +184,11 @@ public class BlockCommands {
             Block b = (Block) in[0].get(sc);
             Leaves o = (Leaves) b.getBlockData();
             return o.isPersistent();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("block.isleaves",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Leaves);
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Leaves, "boolean");
         MundusPlugin.scriptManager.registerFunction("block.isbed",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Bed);
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Bed, "boolean");
         MundusPlugin.scriptManager.registerConsumer("block.setbedpart", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Bed o = (Bed) b.getBlockData();
@@ -199,14 +199,14 @@ public class BlockCommands {
             Block b = (Block) in[0].get(sc);
             Bed o = (Bed) b.getBlockData();
             return o.getPart().toString();
-        });
+        }, "string");
         MundusPlugin.scriptManager.registerFunction("block.canhavewater",
-                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Waterlogged);
+                (sc, in) -> ((Block) in[0].get(sc)).getBlockData() instanceof Waterlogged, "boolean");
         MundusPlugin.scriptManager.registerFunction("block.iswaterlogged", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Waterlogged o = (Waterlogged) b.getBlockData();
             return o.isWaterlogged();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerConsumer("block.setwaterlogged", (sc, in) -> {
             Block b = (Block) in[0].get(sc);
             Waterlogged o = (Waterlogged) b.getBlockData();

--- a/src/me/hammerle/mp/snuviscript/commands/BossBarCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/BossBarCommands.java
@@ -13,7 +13,7 @@ public class BossBarCommands {
         MundusPlugin.scriptManager.registerFunction("boss.create", (sc, in) -> {
             return Bukkit.createBossBar(in[0].getString(sc), BarColor.valueOf(in[1].getString(sc)),
                     BarStyle.valueOf(in[2].getString(sc)));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("boss.addplayer", (sc, in) -> {
             ((BossBar) in[0].get(sc)).addPlayer((Player) in[1].get(sc));
         });

--- a/src/me/hammerle/mp/snuviscript/commands/CitizenCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/CitizenCommands.java
@@ -18,7 +18,7 @@ public class CitizenCommands {
                     CitizensAPI.getNPCRegistry().createNPC(EntityType.PLAYER, in[1].getString(sc));
             npc.spawn(l);
             return npc;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("citizen.despawn", (sc, in) -> {
             NPC npc = (NPC) in[0].get(sc);
             npc.despawn();
@@ -39,7 +39,7 @@ public class CitizenCommands {
         MundusPlugin.scriptManager.registerFunction("citizen.getname", (sc, in) -> {
             NPC npc = (NPC) in[0].get(sc);
             return npc.getName();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("citizen.shownameplate", (sc, in) -> {
             NPC npc = (NPC) in[0].get(sc);
             npc.data().set(NPC.Metadata.NAMEPLATE_VISIBLE, in[1].getBoolean(sc));

--- a/src/me/hammerle/mp/snuviscript/commands/CommandCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/CommandCommands.java
@@ -30,14 +30,14 @@ public class CommandCommands {
         MundusPlugin.scriptManager.registerConsumer("command.remove",
                 (sc, in) -> CommandManager.removeCustom(in[0].getString(sc)));
         MundusPlugin.scriptManager.registerFunction("command.exists",
-                (sc, in) -> CommandManager.hasCustom(in[0].getString(sc)));
+                (sc, in) -> CommandManager.hasCustom(in[0].getString(sc)), "boolean");
         MundusPlugin.scriptManager.registerConsumer("command.clear",
                 (sc, in) -> CommandManager.clearCustom());
         //commandhelp creation
         MundusPlugin.scriptManager.registerFunction("command.newhelp", (sc, in) -> {
             final String perm = in[1].getString(sc);
             return new CommandAPICommand(in[0].getString(sc)).withPermission(perm);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("command.addhelpargument", (sc, in) -> {
             CommandAPICommand cmd = (CommandAPICommand) in[0].get(sc);
             Argument<?> arg = (Argument<?>) in[1].get(sc);
@@ -68,7 +68,7 @@ public class CommandCommands {
                 arg.withPermission(perm);
             }
             return arg;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("command.newhelpliteral", (sc, in) -> {
             String literal = in[0].getString(sc);
             Argument<?> arg = new LiteralArgument(literal)
@@ -78,7 +78,7 @@ public class CommandCommands {
                 arg.withPermission(perm);
             }
             return arg;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("command.newhelpbool", (sc, in) -> {
             String name = in[0].getString(sc);
             Argument<?> arg = new BooleanArgument(name);
@@ -87,7 +87,7 @@ public class CommandCommands {
                 arg.withPermission(perm);
             }
             return arg;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("command.newhelpfloat", (sc, in) -> {
             float min = in[1].getFloat(sc);
             float max = in[2].getFloat(sc);
@@ -98,7 +98,7 @@ public class CommandCommands {
                 arg.withPermission(perm);
             }
             return arg;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("command.newhelpdouble", (sc, in) -> {
             double min = in[1].getDouble(sc);
             double max = in[2].getDouble(sc);
@@ -109,7 +109,7 @@ public class CommandCommands {
                 arg.withPermission(perm);
             }
             return arg;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("command.newhelpint", (sc, in) -> {
             int min = in[1].getInt(sc);
             int max = in[2].getInt(sc);
@@ -120,7 +120,7 @@ public class CommandCommands {
                 arg.withPermission(perm);
             }
             return arg;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("command.newhelpspecial", (sc, in) -> {
             Argument<?> arg = null;
             String type = in[0].getString(sc);
@@ -156,6 +156,6 @@ public class CommandCommands {
                 arg.withPermission(perm);
             }
             return arg;
-        });
+        }, "object");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/Commands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/Commands.java
@@ -16,18 +16,18 @@ public class Commands {
         });
         MundusPlugin.scriptManager.registerFunction("getmotd", (sc, in) -> {
             return org.bukkit.Bukkit.motd();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("msg", (sc, in) -> {
             CommandUtils.sendMessageToGroup(in[0].get(sc), sc, (Component) in[1].get(sc));
         });
         MundusPlugin.scriptManager.registerFunction("isplayer", (sc, in) -> {
             Object o = in[0].get(sc);
             return o != null && o instanceof Player && !((Player) o).hasMetadata("NPC");
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("isliving", (sc, in) -> {
             Object o = in[0].get(sc);
             return o != null && o instanceof LivingEntity;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("iscitizen", (sc, in) -> {
             Object o = in[0].get(sc);
             if(o == null) {
@@ -37,7 +37,7 @@ public class Commands {
                 return true;
             }
             return o instanceof Entity && ((Entity) o).hasMetadata("NPC");
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("config.saveasync", (sc, in) -> {
             SnuviConfig config = (SnuviConfig) in[0].get(sc);
             MundusPlugin.scheduleAsyncTask(() -> config.save(sc));

--- a/src/me/hammerle/mp/snuviscript/commands/DamageCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DamageCommands.java
@@ -13,27 +13,27 @@ public class DamageCommands {
         MundusPlugin.scriptManager.registerFunction("damage.get", (sc, in) -> {
             DamageType dt = parseDamageType(in[0].getString(sc));
             return DamageSource.builder(dt).build();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("damage.gettype", (sc, in) -> {
             DamageSource d = (DamageSource) in[0].get(sc);
             return d.getDamageType().getTranslationKey();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("damage.getimmediatesource", (sc, in) -> {
             DamageSource d = (DamageSource) in[0].get(sc);
             return d.getDirectEntity();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("damage.gettruesource", (sc, in) -> {
             DamageSource d = (DamageSource) in[0].get(sc);
             return d.getCausingEntity();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("damage.isindirect", (sc, in) -> {
             DamageSource d = (DamageSource) in[0].get(sc);
             return d.isIndirect();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("damage.isdifficultyscaled", (sc, in) -> {
             DamageSource d = (DamageSource) in[0].get(sc);
             return d.scalesWithDifficulty();
-        });
+        }, "object");
     }
 
     public static DamageType parseDamageType(String name) {

--- a/src/me/hammerle/mp/snuviscript/commands/DataCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DataCommands.java
@@ -20,12 +20,12 @@ public class DataCommands {
             Player p = (Player) in[0].get(sc);
             PlayerData data = PlayerData.get(p);
             return data.getData(in[1].getString(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("data.gettimer", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             PlayerData data = PlayerData.get(p);
             return (double) data.getTimer(in[1].getString(sc));
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerConsumer("data.clear", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             PlayerData data = PlayerData.get(p);

--- a/src/me/hammerle/mp/snuviscript/commands/DatabaseCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DatabaseCommands.java
@@ -14,7 +14,7 @@ public class DatabaseCommands {
                 sc.addCloseable(p);
             }
             return p;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("databank.setint", (sc, in) -> {
             ((Database.SafeStatement) in[0].get(sc)).setInt(in[1].getInt(sc), in[2].getInt(sc));
         });
@@ -34,17 +34,17 @@ public class DatabaseCommands {
                     in[2].getBoolean(sc));
         });
         MundusPlugin.scriptManager.registerFunction("databank.getint",
-                (sc, in) -> (double) ((ResultSet) in[0].get(sc)).getInt(in[1].getInt(sc)));
+                (sc, in) -> (double) ((ResultSet) in[0].get(sc)).getInt(in[1].getInt(sc)), "number");
         MundusPlugin.scriptManager.registerFunction("databank.getlong",
-                (sc, in) -> (double) ((ResultSet) in[0].get(sc)).getLong(in[1].getInt(sc)));
+                (sc, in) -> (double) ((ResultSet) in[0].get(sc)).getLong(in[1].getInt(sc)), "number");
         MundusPlugin.scriptManager.registerFunction("databank.getdouble",
-                (sc, in) -> ((ResultSet) in[0].get(sc)).getDouble(in[1].getInt(sc)));
+                (sc, in) -> ((ResultSet) in[0].get(sc)).getDouble(in[1].getInt(sc)), "number");
         MundusPlugin.scriptManager.registerFunction("databank.getstring",
-                (sc, in) -> ((ResultSet) in[0].get(sc)).getString(in[1].getInt(sc)));
+                (sc, in) -> ((ResultSet) in[0].get(sc)).getString(in[1].getInt(sc)), "string");
         MundusPlugin.scriptManager.registerFunction("databank.getbool",
-                (sc, in) -> ((ResultSet) in[0].get(sc)).getBoolean(in[1].getInt(sc)));
+                (sc, in) -> ((ResultSet) in[0].get(sc)).getBoolean(in[1].getInt(sc)), "boolean");
         MundusPlugin.scriptManager.registerFunction("databank.execute",
-                (sc, in) -> ((Database.SafeStatement) in[0].get(sc)).executeQuery());
+                (sc, in) -> ((Database.SafeStatement) in[0].get(sc)).executeQuery(), "object");
         MundusPlugin.scriptManager.registerConsumer("databank.workerexecute", (sc, in) -> {
             final Database.SafeStatement p = (Database.SafeStatement) in[0].get(sc);
             StackTrace lines = sc.getStackTrace();
@@ -70,7 +70,7 @@ public class DatabaseCommands {
             });
         });
         MundusPlugin.scriptManager.registerFunction("databank.next",
-                (sc, in) -> ((ResultSet) in[0].get(sc)).next());
+                (sc, in) -> ((ResultSet) in[0].get(sc)).next(), "boolean");
         MundusPlugin.scriptManager.registerConsumer("databank.close", (sc, in) -> {
             AutoCloseable auto = (AutoCloseable) in[0].get(sc);
             auto.close();

--- a/src/me/hammerle/mp/snuviscript/commands/DisplayCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/DisplayCommands.java
@@ -34,7 +34,7 @@ public class DisplayCommands {
                 entity.text(text);
             });
             return d;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("display.backgroundcolor", (sc, in) -> {
             TextDisplay d = (TextDisplay) in[0].get(sc);
             Color c = Color.fromARGB(in[1].getInt(sc), in[2].getInt(sc), in[3].getInt(sc),
@@ -76,7 +76,7 @@ public class DisplayCommands {
                 entity.setBlock(m.createBlockData());
             });
             return d;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("display.setblock", (sc, in) -> {
             BlockDisplay b = (BlockDisplay) in[0].get(sc);
             Material m = (Material) in[1].get(sc);
@@ -92,7 +92,7 @@ public class DisplayCommands {
                 entity.setItemStack(stack);
             });
             return d;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("display.setitem", (sc, in) -> {
             ItemDisplay d = (ItemDisplay) in[0].get(sc);
             ItemStack stack = (ItemStack) in[1].get(sc);
@@ -113,9 +113,9 @@ public class DisplayCommands {
         });
         MundusPlugin.scriptManager.registerFunction("vector.new",
                 (sc, in) -> new Vector3f(in[0].getFloat(sc), in[1].getFloat(sc),
-                        in[2].getFloat(sc)));
+                        in[2].getFloat(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("rotation.new",
                 (sc, in) -> new Quaternionf(in[0].getFloat(sc), in[1].getFloat(sc),
-                        in[2].getFloat(sc), in[3].getFloat(sc)));
+                        in[2].getFloat(sc), in[3].getFloat(sc)), "object");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/EnchantmentCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/EnchantmentCommands.java
@@ -14,16 +14,16 @@ public class EnchantmentCommands {
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("enchantment.get",
                 (sc, in) -> RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT)
-                        .get(NamespacedKey.fromString(in[0].getString(sc))));
+                        .get(NamespacedKey.fromString(in[0].getString(sc))), "object");
         MundusPlugin.scriptManager.registerFunction("enchantment.getmaxlevel",
-                (sc, in) -> (double) ((Enchantment) in[0].get(sc)).getMaxLevel());
+                (sc, in) -> (double) ((Enchantment) in[0].get(sc)).getMaxLevel(), "object");
         MundusPlugin.scriptManager.registerConsumer("enchantment.add", (sc, in) -> {
             ((ItemStack) in[1].get(sc)).addUnsafeEnchantment((Enchantment) in[0].get(sc),
                     in[2].getInt(sc));
         });
         MundusPlugin.scriptManager.registerFunction("enchantment.getlevel",
                 (sc, in) -> (double) ((ItemStack) in[1].get(sc))
-                        .getEnchantmentLevel((Enchantment) in[0].get(sc)));
+                        .getEnchantmentLevel((Enchantment) in[0].get(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("enchantment.readfromitem", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             HashMap<Enchantment, Double> map = new HashMap<>();
@@ -31,7 +31,7 @@ public class EnchantmentCommands {
                 map.put(e.getKey(), (double) e.getValue());
             }
             return map;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("enchantment.writetoitem", (sc, in) -> {
             ItemStack stack = (ItemStack) in[1].get(sc);
             for(Enchantment e : stack.getEnchantments().keySet()) {

--- a/src/me/hammerle/mp/snuviscript/commands/EntityCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/EntityCommands.java
@@ -35,7 +35,7 @@ public class EntityCommands {
         MundusPlugin.scriptManager.registerConsumer("entity.setburning",
                 (sc, in) -> ((Entity) in[0].get(sc)).setFireTicks(in[1].getInt(sc)));
         MundusPlugin.scriptManager.registerFunction("entity.isburning",
-                (sc, in) -> ((Entity) in[0].get(sc)).getFireTicks() > 0);
+                (sc, in) -> ((Entity) in[0].get(sc)).getFireTicks() > 0, "boolean");
         MundusPlugin.scriptManager.registerFunction("entity.getlook", (sc, in) -> {
             Object[] o = new Object[3];
             Vector v = ((Entity) in[0].get(sc)).getLocation().getDirection();
@@ -43,7 +43,7 @@ public class EntityCommands {
             o[1] = v.getY();
             o[2] = v.getZ();
             return o;
-        });
+        }, "array");
         MundusPlugin.scriptManager.registerConsumer("entity.setlook", (sc, in) -> {
             Entity e = (Entity) in[0].get(sc);
             Location l = e.getLocation();
@@ -58,9 +58,9 @@ public class EntityCommands {
             o[1] = v.getY();
             o[2] = v.getZ();
             return o;
-        });
+        }, "array");
         MundusPlugin.scriptManager.registerFunction("entity.getlocation",
-                (sc, in) -> ((Entity) in[0].get(sc)).getLocation());
+                (sc, in) -> ((Entity) in[0].get(sc)).getLocation(), "location");
         MundusPlugin.scriptManager.registerConsumer("entity.setname", (sc, in) -> {
             Entity ent = (Entity) in[0].get(sc);
             ent.customName((Component) in[1].get(sc));
@@ -71,7 +71,7 @@ public class EntityCommands {
             ent.setCustomNameVisible(false);
         });
         MundusPlugin.scriptManager.registerFunction("entity.getname",
-                (sc, in) -> ((Entity) in[0].get(sc)).customName());
+                (sc, in) -> ((Entity) in[0].get(sc)).customName(), "text");
         MundusPlugin.scriptManager.registerConsumer("entity.setmotion", (sc, in) -> {
             Entity ent = (Entity) in[0].get(sc);
             ent.setVelocity(
@@ -98,9 +98,9 @@ public class EntityCommands {
             ((Entity) in[0].get(sc)).setSilent(in[1].getBoolean(sc));
         });
         MundusPlugin.scriptManager.registerFunction("entity.getmount",
-                (sc, in) -> ((Entity) in[0].get(sc)).getVehicle());
+                (sc, in) -> ((Entity) in[0].get(sc)).getVehicle(), "entity");
         MundusPlugin.scriptManager.registerFunction("entity.getpassengers",
-                (sc, in) -> ((Entity) in[0].get(sc)).getPassengers());
+                (sc, in) -> ((Entity) in[0].get(sc)).getPassengers(), "list");
         MundusPlugin.scriptManager.registerConsumer("entity.mount", (sc, in) -> {
             ((Entity) in[1].get(sc)).addPassenger(((Entity) in[0].get(sc)));
         });
@@ -120,18 +120,18 @@ public class EntityCommands {
                 }
             }
             return minE;
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerFunction("entity.getpotiontype",
-                (sc, in) -> ((ThrownPotion) in[0].get(sc)).getItem());
+                (sc, in) -> ((ThrownPotion) in[0].get(sc)).getItem(), "itemstack");
         MundusPlugin.scriptManager.registerConsumer("entity.setgravity", (sc, in) -> {
             ((Entity) in[0].get(sc)).setGravity(in[1].getBoolean(sc));
         });
         MundusPlugin.scriptManager.registerFunction("entity.iswet",
-                (sc, in) -> ((Entity) in[0].get(sc)).isInWater());
+                (sc, in) -> ((Entity) in[0].get(sc)).isInWater(), "boolean");
         MundusPlugin.scriptManager.registerFunction("entity.spawn", (sc, in) -> {
             Location l = ((Location) in[0].get(sc));
             return l.getWorld().spawnEntity(l, EntityType.valueOf(in[1].getString(sc)));
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerFunction("entity.near", (sc, in) -> {
             Object o = in[0].get(sc);
             if(o instanceof Location) {
@@ -141,11 +141,11 @@ public class EntityCommands {
             Entity ent = (Entity) o;
             double radius = in[1].getDouble(sc);
             return ent.getNearbyEntities(radius, radius, radius);
-        });
+        }, "list");
         MundusPlugin.scriptManager.registerFunction("entity.getuuid", (sc, in) -> {
             Entity ent = (Entity) in[0].get(sc);
             return ent.getUniqueId();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("entity.setgrowingage", (sc, in) -> {
             ((Ageable) in[0].get(sc)).setAge(in[1].getInt(sc));
         });
@@ -156,7 +156,7 @@ public class EntityCommands {
             ((Breedable) in[0].get(sc)).setBreed(in[1].getBoolean(sc));
         });
         MundusPlugin.scriptManager.registerFunction("entity.isbreedable",
-                (sc, in) -> ((Breedable) in[0].get(sc)).canBreed());
+                (sc, in) -> ((Breedable) in[0].get(sc)).canBreed(), "boolean");
         MundusPlugin.scriptManager.registerConsumer("entity.setadult", (sc, in) -> {
             ((Ageable) in[0].get(sc)).setAdult();
         });
@@ -164,13 +164,13 @@ public class EntityCommands {
             ((Ageable) in[0].get(sc)).setBaby();
         });
         MundusPlugin.scriptManager.registerFunction("entity.isadult",
-                (sc, in) -> ((Ageable) in[0].get(sc)).isAdult());
+                (sc, in) -> ((Ageable) in[0].get(sc)).isAdult(), "boolean");
         MundusPlugin.scriptManager.registerFunction("entity.gettype",
-                (sc, in) -> ((Entity) in[0].get(sc)).getType().toString().toLowerCase());
+                (sc, in) -> ((Entity) in[0].get(sc)).getType().toString().toLowerCase(), "string");
         MundusPlugin.scriptManager.registerFunction("sheep.issheared",
-                (sc, in) -> ((Sheep) in[0].get(sc)).isSheared());
+                (sc, in) -> ((Sheep) in[0].get(sc)).isSheared(), "boolean");
         MundusPlugin.scriptManager.registerFunction("sheep.getcolor",
-                (sc, in) -> ((Sheep) in[0].get(sc)).getColor().toString());
+                (sc, in) -> ((Sheep) in[0].get(sc)).getColor().toString(), "string");
         MundusPlugin.scriptManager.registerConsumer("creeper.explode",
                 (sc, in) -> ((Creeper) in[0].get(sc)).ignite());
         MundusPlugin.scriptManager.registerFunction("rabbit.spawnkillerbunny", (sc, in) -> {
@@ -178,10 +178,10 @@ public class EntityCommands {
             Rabbit r = (Rabbit) l.getWorld().spawnEntity(l, EntityType.RABBIT);
             r.setRabbitType(Type.THE_KILLER_BUNNY);
             return r;
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerFunction("pet.istamed", (sc, in) -> {
             return ((Tameable) in[0].get(sc)).isTamed();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerConsumer("pet.settamed", (sc, in) -> {
             Tameable t = (Tameable) in[0].get(sc);
             t.setTamed(in[1].getBoolean(sc));
@@ -192,7 +192,7 @@ public class EntityCommands {
         MundusPlugin.scriptManager.registerFunction("pet.getowner", (sc, in) -> {
             Tameable t = (Tameable) in[0].get(sc);
             return t.getOwner();
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerFunction("entity.spawnseat", (sc, in) -> {
             Location l = ((Location) in[0].get(sc));
             ItemFrame frame = l.getWorld().spawn(l, ItemFrame.class);
@@ -200,7 +200,7 @@ public class EntityCommands {
             frame.setVisible(false);
             frame.setFacingDirection(BlockFace.UP);
             return (ItemFrame) frame;
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerConsumer("entity.frame.hide", (sc, in) -> {
             ItemFrame frame = (ItemFrame) in[0].get(sc);
             frame.setVisible(false);
@@ -225,11 +225,11 @@ public class EntityCommands {
             frame.setItem((ItemStack) in[2].get(sc));
         });
         MundusPlugin.scriptManager.registerFunction("entity.frame.getitem",
-                (sc, in) -> ((ItemFrame) in[0].get(sc)).getItem());
+                (sc, in) -> ((ItemFrame) in[0].get(sc)).getItem(), "itemstack");
         MundusPlugin.scriptManager.registerFunction("slime.getsize", (sc, in) -> {
             Slime s = (Slime) in[0].get(sc);
             return (double) s.getSize();
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerConsumer("slime.setsize", (sc, in) -> {
             Slime s = (Slime) in[0].get(sc);
             s.setSize(in[1].getInt(sc));

--- a/src/me/hammerle/mp/snuviscript/commands/ErrorCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ErrorCommands.java
@@ -9,13 +9,13 @@ public class ErrorCommands {
         });
         MundusPlugin.scriptManager.registerFunction("error.getsize", (sc, in) -> {
             return (double) MundusPlugin.logger.getErrorHistory().getLength();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("error.getindex", (sc, in) -> {
             return MundusPlugin.logger.getErrorHistory().get(in[0].getInt(sc)).message;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("error.getindextime", (sc, in) -> {
             return (double) MundusPlugin.logger.getErrorHistory().get(in[0].getInt(sc)).timestamp;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("error.setconsoleprint", (sc, in) -> {
             MundusPlugin.logger.setConsoleErrorLogging(in[0].getBoolean(sc));
         });
@@ -24,13 +24,13 @@ public class ErrorCommands {
         });
         MundusPlugin.scriptManager.registerFunction("debug.getsize", (sc, in) -> {
             return (double) MundusPlugin.logger.getDebugHistory().getLength();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("debug.getindex", (sc, in) -> {
             return MundusPlugin.logger.getDebugHistory().get(in[0].getInt(sc)).message;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("debug.getindextime", (sc, in) -> {
             return (double) MundusPlugin.logger.getDebugHistory().get(in[0].getInt(sc)).timestamp;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("debug.setconsoleprint", (sc, in) -> {
             MundusPlugin.logger.setConsoleDebugLogging(in[0].getBoolean(sc));
         });

--- a/src/me/hammerle/mp/snuviscript/commands/EventCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/EventCommands.java
@@ -12,7 +12,7 @@ public class EventCommands {
             MoveEvents.Data pmd = new MoveEvents.Data(sc, (Location) in[0].get(sc),
                     (Location) in[1].get(sc), in[2].getInt(sc), in[3].getInt(sc), uuid);
             return (double) MoveEvents.add(pmd);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("event.removemovedata",
                 (sc, in) -> MoveEvents.remove(in[0].getInt(sc)));
     }

--- a/src/me/hammerle/mp/snuviscript/commands/GameRuleCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/GameRuleCommands.java
@@ -8,18 +8,18 @@ public class GameRuleCommands {
     @SuppressWarnings("unchecked")
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("gamerule.getall",
-                (sc, in) -> GameRule.values());
+                (sc, in) -> GameRule.values(), "object");
         MundusPlugin.scriptManager.registerFunction("gamerule.isbool", (sc, in) -> {
             GameRule<?> rule = (GameRule<?>) in[0].get(sc);
             return rule.getType().equals(Boolean.class);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("gamerule.getname", (sc, in) -> {
             GameRule<?> rule = (GameRule<?>) in[0].get(sc);
             return rule.getName();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("gamerule.getkey", (sc, in) -> {
             return GameRule.getByName(in[0].getString(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("gamerule.getvalue", (sc, in) -> {
             World w = (World) in[0].get(sc);
             GameRule<?> rule = (GameRule<?>) in[1].get(sc);
@@ -28,7 +28,7 @@ public class GameRuleCommands {
                 return ((Number) o).doubleValue();
             }
             return o;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("gamerule.setbool", (sc, in) -> {
             World w = (World) in[0].get(sc);
             GameRule<Boolean> rule = (GameRule<Boolean>) in[1].get(sc);

--- a/src/me/hammerle/mp/snuviscript/commands/InventoryCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/InventoryCommands.java
@@ -14,14 +14,14 @@ import net.kyori.adventure.text.Component;
 public class InventoryCommands {
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("inv.new", (sc, in) -> SnuviInventoryHolder
-                .create(in[0].getString(sc), (Component) in[1].get(sc)));
+                .create(in[0].getString(sc), (Component) in[1].get(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("inv.getid", (sc, in) -> {
             Inventory inv = (Inventory) in[0].get(sc);
             if(inv.getHolder() instanceof SnuviInventoryHolder) {
                 return (double) ((SnuviInventoryHolder) inv.getHolder()).getId();
             }
             return -1;
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerConsumer("inv.setitem", (sc, in) -> {
             Inventory inv = (Inventory) in[0].get(sc);
             int index = in[1].getInt(sc);
@@ -35,9 +35,9 @@ public class InventoryCommands {
             inv.setItem(index, stack);
         });
         MundusPlugin.scriptManager.registerFunction("inv.getitem",
-                (sc, in) -> ((Inventory) in[0].get(sc)).getItem(in[1].getInt(sc)));
+                (sc, in) -> ((Inventory) in[0].get(sc)).getItem(in[1].getInt(sc)), "itemstack");
         MundusPlugin.scriptManager.registerFunction("inv.getsize",
-                (sc, in) -> (double) ((Inventory) in[0].get(sc)).getSize());
+                (sc, in) -> (double) ((Inventory) in[0].get(sc)).getSize(), "number");
         MundusPlugin.scriptManager.registerConsumer("inv.open", (sc, in) -> {
             ((Player) in[1].get(sc)).openInventory((Inventory) in[0].get(sc));
         });

--- a/src/me/hammerle/mp/snuviscript/commands/ItemCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ItemCommands.java
@@ -28,43 +28,43 @@ public class ItemCommands {
     @SuppressWarnings("unchecked")
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("material.get",
-                (sc, in) -> Material.matchMaterial(in[0].getString(sc)));
+                (sc, in) -> Material.matchMaterial(in[0].getString(sc)), "material");
         MundusPlugin.scriptManager.registerFunction("material.getall",
-                (sc, in) -> Material.values());
+                (sc, in) -> Material.values(), "array");
         MundusPlugin.scriptManager.registerConsumer("material.setcooldown", (sc, in) -> {
             Player p = (Player) in[1].get(sc);
             p.setCooldown((Material) in[0].get(sc), in[2].getInt(sc));
         });
         MundusPlugin.scriptManager.registerFunction("material.getslot",
-                (sc, in) -> ((Material) in[0].get(sc)).getEquipmentSlot());
+                (sc, in) -> ((Material) in[0].get(sc)).getEquipmentSlot(), "object");
         MundusPlugin.scriptManager.registerFunction("material.isitem",
-                (sc, in) -> ((Material) in[0].get(sc)).isItem());
+                (sc, in) -> ((Material) in[0].get(sc)).isItem(), "boolean");
         MundusPlugin.scriptManager.registerFunction("material.issolid",
-                (sc, in) -> ((Material) in[0].get(sc)).isSolid());
+                (sc, in) -> ((Material) in[0].get(sc)).isSolid(), "boolean");
         MundusPlugin.scriptManager.registerFunction("material.isblock",
-                (sc, in) -> ((Material) in[0].get(sc)).isBlock());
+                (sc, in) -> ((Material) in[0].get(sc)).isBlock(), "boolean");
         MundusPlugin.scriptManager.registerFunction("material.isedible",
-                (sc, in) -> ((Material) in[0].get(sc)).isEdible());
+                (sc, in) -> ((Material) in[0].get(sc)).isEdible(), "boolean");
 
         MundusPlugin.scriptManager.registerFunction("item.new",
                 (sc, in) -> new ItemStack((Material) in[0].get(sc),
-                        in.length >= 2 ? in[1].getInt(sc) : 1));
+                        in.length >= 2 ? in[1].getInt(sc) : 1), "itemstack");
         MundusPlugin.scriptManager.registerFunction("item.drop", (sc, in) -> {
             Location l = (Location) in[1].get(sc);
             return l.getWorld().dropItem(l, (ItemStack) in[0].get(sc));
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerFunction("item.gettag",
                 (sc, in) -> Bukkit.getTag(Tag.REGISTRY_ITEMS,
-                        NamespacedKey.fromString(in[0].getString(sc)), Material.class));
+                        NamespacedKey.fromString(in[0].getString(sc)), Material.class), "object");
         MundusPlugin.scriptManager.registerFunction("item.hastag",
                 (sc, in) -> ((Tag<Material>) in[1].get(sc))
-                        .isTagged(((ItemStack) in[0].get(sc)).getType()));
+                        .isTagged(((ItemStack) in[0].get(sc)).getType()), "boolean");
         MundusPlugin.scriptManager.registerFunction("item.gettype",
-                (sc, in) -> ((ItemStack) in[0].get(sc)).getType());
+                (sc, in) -> ((ItemStack) in[0].get(sc)).getType(), "material");
         MundusPlugin.scriptManager.registerFunction("item.getmaxamount",
-                (sc, in) -> (double) ((ItemStack) in[0].get(sc)).getMaxStackSize());
+                (sc, in) -> (double) ((ItemStack) in[0].get(sc)).getMaxStackSize(), "number");
         MundusPlugin.scriptManager.registerFunction("item.getamount",
-                (sc, in) -> (double) ((ItemStack) in[0].get(sc)).getAmount());
+                (sc, in) -> (double) ((ItemStack) in[0].get(sc)).getAmount(), "number");
         MundusPlugin.scriptManager.registerConsumer("item.setamount",
                 (sc, in) -> ((ItemStack) in[0].get(sc)).setAmount(in[1].getInt(sc)));
         MundusPlugin.scriptManager.registerFunction("item.hasname", (sc, in) -> {
@@ -73,14 +73,14 @@ public class ItemCommands {
                 return false;
             }
             return stack.getItemMeta().hasDisplayName();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("item.getname", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             if(stack.getItemMeta() == null) {
                 return null;
             }
             return stack.getItemMeta().displayName();
-        });
+        }, "text");
         MundusPlugin.scriptManager.registerConsumer("item.setname", (sc, in) -> {
             ((ItemStack) in[0].get(sc))
                     .editMeta(meta -> meta.displayName((Component) in[1].get(sc)));
@@ -91,7 +91,7 @@ public class ItemCommands {
                 return new ArrayList<Component>();
             }
             return stack.getItemMeta().lore();
-        });
+        }, "list");
         MundusPlugin.scriptManager.registerConsumer("item.setlore", (sc, in) -> {
             ((ItemStack) in[0].get(sc))
                     .editMeta(meta -> meta.lore((List<Component>) in[1].get(sc)));
@@ -123,7 +123,7 @@ public class ItemCommands {
                     })
                     .sorted()
                     .collect(Collectors.toList());
-        });
+        }, "list");
         MundusPlugin.scriptManager.registerConsumer("item.addattribute", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             stack.editMeta(meta -> {
@@ -176,7 +176,7 @@ public class ItemCommands {
                 return false;
             }
             return stack.getItemMeta().hasAttributeModifiers();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerConsumer("item.adddefaulttags", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             stack.editMeta(meta -> {
@@ -189,20 +189,20 @@ public class ItemCommands {
             });
         });
         MundusPlugin.scriptManager.registerFunction("item.clone",
-                (sc, in) -> ((ItemStack) in[0].get(sc)).clone());
+                (sc, in) -> ((ItemStack) in[0].get(sc)).clone(), "itemstack");
         MundusPlugin.scriptManager.registerFunction("item.getmaxdamage", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             return (double) stack.getType().getMaxDurability();
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerFunction("item.isdamageable", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             return stack.getItemMeta() instanceof Damageable;
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("item.getdamage", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             Damageable damage = (Damageable) stack.getItemMeta();
             return (double) damage.getDamage();
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerConsumer("item.setdamage", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             Damageable damage = (Damageable) stack.getItemMeta();

--- a/src/me/hammerle/mp/snuviscript/commands/ItemEntityCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ItemEntityCommands.java
@@ -16,7 +16,7 @@ public class ItemEntityCommands {
                 return ((ThrowableProjectile) o).getItem();
             }
             return ((Item) o).getItemStack();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("item.entity.set", (sc, in) -> {
             Object o = in[0].get(sc);
             ItemStack stack = (ItemStack) in[1].get(sc);

--- a/src/me/hammerle/mp/snuviscript/commands/LivingCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/LivingCommands.java
@@ -49,7 +49,7 @@ public class LivingCommands {
                 if(instance == null)
                     return 0.0;
                 return instance.getBaseValue();
-            });
+            }, "number");
 
             MundusPlugin.scriptManager.registerConsumer(resetCmd, (sc, in) -> {
                 LivingEntity liv = (LivingEntity) in[0].get(sc);
@@ -73,9 +73,9 @@ public class LivingCommands {
                 l = ((LivingEntity) o).getLocation();
             }
             return l.getWorld().getNearbyLivingEntities(l, in[1].getDouble(sc));
-        });
+        }, "list");
         MundusPlugin.scriptManager.registerFunction("living.gethealth",
-                (sc, in) -> (double) ((LivingEntity) in[0].get(sc)).getHealth());
+                (sc, in) -> (double) ((LivingEntity) in[0].get(sc)).getHealth(), "number");
         MundusPlugin.scriptManager.registerConsumer("living.sethealth",
                 (sc, in) -> ((LivingEntity) in[0].get(sc)).setHealth(in[1].getDouble(sc)));
         MundusPlugin.scriptManager.registerConsumer("living.damage", (sc, in) -> {
@@ -110,7 +110,7 @@ public class LivingCommands {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             return liv.launchProjectile(
                     (Class<? extends Projectile>) Class.forName(in[1].getString(sc)));
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerConsumer("living.setequip", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             liv.getEquipment().setItem((EquipmentSlot) in[1].get(sc), (ItemStack) in[2].get(sc));
@@ -118,7 +118,7 @@ public class LivingCommands {
         MundusPlugin.scriptManager.registerFunction("living.getequip", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             return liv.getEquipment().getItem((EquipmentSlot) in[1].get(sc));
-        });
+        }, "itemstack");
         MundusPlugin.scriptManager.registerConsumer("living.setinvisible", (sc, in) -> {
             ((LivingEntity) in[0].get(sc)).setInvisible(in[1].getBoolean(sc));
         });
@@ -142,27 +142,27 @@ public class LivingCommands {
             PotionEffectType effectType = Registry.POTION_EFFECT_TYPE.get(key);
             PotionEffect effect = ((LivingEntity) in[0].get(sc)).getPotionEffect(effectType);
             return (double) (effect == null ? -1 : effect.getAmplifier());
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerFunction("living.isgliding", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             return liv.isGliding();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("living.isswimming", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             return liv.isSwimming();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("living.isglowing", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             return liv.isGlowing();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("living.issleeping", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             return liv.isSleeping();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("living.isleashed", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             return liv.isLeashed();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("living.getleashholder", (sc, in) -> {
             try {
                 LivingEntity liv = (LivingEntity) in[0].get(sc);
@@ -177,7 +177,7 @@ public class LivingCommands {
             } catch(Exception e) {
                 return null;
             }
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("living.setleashholder", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             Object o = in[1].get(sc);
@@ -198,7 +198,7 @@ public class LivingCommands {
                 throw new IllegalArgumentException(
                         "Second argument must be an Entity or a Location.");
             }
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerConsumer("living.unleash", (sc, in) -> {
             LivingEntity liv = (LivingEntity) in[0].get(sc);
             liv.setLeashHolder(null);

--- a/src/me/hammerle/mp/snuviscript/commands/LocationCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/LocationCommands.java
@@ -15,19 +15,19 @@ public class LocationCommands {
             }
             return new Location((World) in[0].get(sc), in[1].getDouble(sc), in[2].getDouble(sc),
                     in[3].getDouble(sc), 0, 0);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("loc.getx",
-                (sc, in) -> ((Location) in[0].get(sc)).getX());
+                (sc, in) -> ((Location) in[0].get(sc)).getX(), "object");
         MundusPlugin.scriptManager.registerFunction("loc.gety",
-                (sc, in) -> ((Location) in[0].get(sc)).getY());
+                (sc, in) -> ((Location) in[0].get(sc)).getY(), "object");
         MundusPlugin.scriptManager.registerFunction("loc.getz",
-                (sc, in) -> ((Location) in[0].get(sc)).getZ());
+                (sc, in) -> ((Location) in[0].get(sc)).getZ(), "object");
         MundusPlugin.scriptManager.registerFunction("loc.getblockx",
-                (sc, in) -> (double) ((Location) in[0].get(sc)).getBlockX());
+                (sc, in) -> (double) ((Location) in[0].get(sc)).getBlockX(), "object");
         MundusPlugin.scriptManager.registerFunction("loc.getblocky",
-                (sc, in) -> (double) ((Location) in[0].get(sc)).getBlockY());
+                (sc, in) -> (double) ((Location) in[0].get(sc)).getBlockY(), "object");
         MundusPlugin.scriptManager.registerFunction("loc.getblockz",
-                (sc, in) -> (double) ((Location) in[0].get(sc)).getBlockZ());
+                (sc, in) -> (double) ((Location) in[0].get(sc)).getBlockZ(), "object");
         MundusPlugin.scriptManager.registerConsumer("loc.set",
                 (sc, in) -> ((Location) in[0].get(sc)).set(in[1].getDouble(sc), in[2].getDouble(sc),
                         in[3].getDouble(sc)));
@@ -49,18 +49,18 @@ public class LocationCommands {
         MundusPlugin.scriptManager.registerConsumer("loc.setyaw",
                 (sc, in) -> ((Location) in[0].get(sc)).setYaw(in[1].getFloat(sc)));
         MundusPlugin.scriptManager.registerFunction("loc.getyaw",
-                (sc, in) -> (double) ((Location) in[0].get(sc)).getYaw());
+                (sc, in) -> (double) ((Location) in[0].get(sc)).getYaw(), "object");
         MundusPlugin.scriptManager.registerConsumer("loc.setpitch",
                 (sc, in) -> ((Location) in[0].get(sc)).setPitch(in[1].getFloat(sc)));
         MundusPlugin.scriptManager.registerFunction("loc.getpitch",
-                (sc, in) -> (double) ((Location) in[0].get(sc)).getPitch());
+                (sc, in) -> (double) ((Location) in[0].get(sc)).getPitch(), "object");
         MundusPlugin.scriptManager.registerFunction("loc.getworld",
-                (sc, in) -> ((Location) in[0].get(sc)).getWorld());
+                (sc, in) -> ((Location) in[0].get(sc)).getWorld(), "object");
         MundusPlugin.scriptManager.registerFunction("loc.distance",
-                (sc, in) -> ((Location) in[0].get(sc)).distance((Location) in[1].get(sc)));
+                (sc, in) -> ((Location) in[0].get(sc)).distance((Location) in[1].get(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("loc.mod",
                 (sc, in) -> ((Location) in[0].get(sc)).clone().add(in[1].getDouble(sc),
-                        in[2].getDouble(sc), in[3].getDouble(sc)));
+                        in[2].getDouble(sc), in[3].getDouble(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("loc.isbetween", (sc, in) -> {
             Location l1 = (Location) in[0].get(sc);
             Location l2 = (Location) in[1].get(sc);
@@ -71,7 +71,7 @@ public class LocationCommands {
                     && l1.getY() <= Math.max(l2.getY(), l3.getY())
                     && l1.getZ() >= Math.min(l2.getZ(), l3.getZ())
                     && l1.getZ() <= Math.max(l2.getZ(), l3.getZ());
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("loc.sort", (sc, in) -> {
             Location l1 = (Location) in[0].get(sc);
             Location l2 = (Location) in[1].get(sc);
@@ -101,7 +101,7 @@ public class LocationCommands {
             }
             return new LocationIterator((World) in[0].get(sc), in[1].getInt(sc), in[2].getInt(sc),
                     in[3].getInt(sc), in[4].getInt(sc), in[5].getInt(sc), in[6].getInt(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("loc.explode", (sc, in) -> {
             Location l = (Location) in[0].get(sc);
             Entity ent = (Entity) in[1].get(sc);

--- a/src/me/hammerle/mp/snuviscript/commands/LuckPermsCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/LuckPermsCommands.java
@@ -102,12 +102,12 @@ public class LuckPermsCommands {
             getLuckPerms().getUserManager().saveUser(user);
         });
         MundusPlugin.scriptManager.registerFunction("luckperms.groupexists",
-                (sc, in) -> loadGroup(in[0].getString(sc)) != null);
+                (sc, in) -> loadGroup(in[0].getString(sc)) != null, "object");
         MundusPlugin.scriptManager.registerFunction("luckperms.getGroups", (sc, in) -> {
             LuckPerms luckPerms = getLuckPerms();
             return luckPerms.getGroupManager().getLoadedGroups().stream().map(Group::getName)
                     .collect(Collectors.toCollection(ArrayList::new));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("luckperms.getgrouppermissions",
                 (sc, in) -> {
                     Group group = loadGroup(in[0].getString(sc));
@@ -117,7 +117,7 @@ public class LuckPermsCommands {
                     return group.getNodes().stream().filter(node -> node instanceof PermissionNode)
                             .map(node -> ((PermissionNode) node).getPermission())
                             .collect(Collectors.toCollection(ArrayList::new));
-                });
+                }, "object");
         MundusPlugin.scriptManager.registerFunction("luckperms.grouphaspermission",
                 (sc, in) -> {
                     Group group = loadGroup(in[0].getString(sc));
@@ -129,27 +129,27 @@ public class LuckPermsCommands {
                             .map(node -> (PermissionNode) node)
                             .anyMatch(node -> node.getPermission().equals(permission)
                                     && node.getValue());
-                });
+                }, "object");
         MundusPlugin.scriptManager.registerFunction("luckperms.getplayergroups", (sc, in) -> {
             User user = loadUser(in[0].get(sc));
             return user.getNodes().stream().filter(node -> node instanceof InheritanceNode)
                     .map(node -> ((InheritanceNode) node).getGroupName())
                     .collect(Collectors.toCollection(ArrayList::new));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("luckperms.isplayeringroup", (sc, in) -> {
             User user = loadUser(in[0].get(sc));
             String group = in[1].getString(sc);
             return user.getNodes().stream().filter(node -> node instanceof InheritanceNode)
                     .map(node -> (InheritanceNode) node)
                     .anyMatch(node -> node.getGroupName().equalsIgnoreCase(group));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("luckperms.getplayerpermissions",
                 (sc, in) -> {
                     User user = loadUser(in[0].get(sc));
                     return user.getNodes().stream().filter(node -> node instanceof PermissionNode)
                             .map(node -> ((PermissionNode) node).getPermission())
                             .collect(Collectors.toCollection(ArrayList::new));
-                });
+                }, "object");
         MundusPlugin.scriptManager.registerFunction("perm.has", (sc, in) -> {
             LuckPerms lp = getLuckPerms();
             if (lp == null) return false;
@@ -170,6 +170,6 @@ public class LuckPermsCommands {
             }
 
             return false;
-        });
+        }, "object");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/ParticleCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ParticleCommands.java
@@ -8,9 +8,9 @@ import me.hammerle.mp.MundusPlugin;
 public class ParticleCommands {
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("particle.getall",
-                (sc, in) -> Particle.values());
+                (sc, in) -> Particle.values(), "object");
         MundusPlugin.scriptManager.registerFunction("particle.get",
-                (sc, in) -> Particle.valueOf(in[0].getString(sc)));
+                (sc, in) -> Particle.valueOf(in[0].getString(sc)), "object");
         MundusPlugin.scriptManager.registerConsumer("particle.spawn", (sc, in) -> {
             Location l = ((Location) in[0].get(sc));
             Particle data = ((Particle) in[1].get(sc));

--- a/src/me/hammerle/mp/snuviscript/commands/PlayerCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/PlayerCommands.java
@@ -74,7 +74,7 @@ public class PlayerCommands {
 
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("player.getitemamount", (sc,
-                in) -> (double) countItemStack((Player) in[0].get(sc), (ItemStack) in[1].get(sc)));
+                in) -> (double) countItemStack((Player) in[0].get(sc), (ItemStack) in[1].get(sc)), "number");
         MundusPlugin.scriptManager.registerFunction("player.removeitem", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             ItemStack stack = (ItemStack) in[1].get(sc);
@@ -84,7 +84,7 @@ public class PlayerCommands {
                 return 0.0;
             }
             return (double) (stack.getAmount() - count);
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerFunction("player.giveitem", (sc, in) -> {
             ItemStack stack = (ItemStack) in[1].get(sc);
             Player p = (Player) in[0].get(sc);
@@ -94,7 +94,7 @@ public class PlayerCommands {
                 count += lStack.getAmount();
             }
             return (double) count;
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerFunction("player.additem", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             ItemStack stack = (ItemStack) in[1].get(sc);
@@ -108,7 +108,7 @@ public class PlayerCommands {
                 p.getInventory().setContents(content);
             }
             return (double) count;
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerConsumer("player.respawn",
                 (sc, in) -> ((Player) in[0].get(sc)).spigot().respawn());
         MundusPlugin.scriptManager.registerConsumer("player.setcompass", (sc, in) -> {
@@ -116,12 +116,12 @@ public class PlayerCommands {
             p.setCompassTarget((Location) in[1].get(sc));
         });
         MundusPlugin.scriptManager.registerFunction("player.gethunger",
-                (sc, in) -> (double) ((Player) in[0].get(sc)).getFoodLevel());
+                (sc, in) -> (double) ((Player) in[0].get(sc)).getFoodLevel(), "number");
         MundusPlugin.scriptManager.registerConsumer("player.sethunger", (sc, in) -> {
             ((Player) in[0].get(sc)).setFoodLevel(in[1].getInt(sc));
         });
         MundusPlugin.scriptManager.registerFunction("player.getsaturation",
-                (sc, in) -> (double) ((Player) in[0].get(sc)).getSaturation());
+                (sc, in) -> (double) ((Player) in[0].get(sc)).getSaturation(), "number");
         MundusPlugin.scriptManager.registerConsumer("player.setsaturation",
                 (sc, in) -> ((Player) in[0].get(sc)).setSaturation(in[1].getFloat(sc)));
         MundusPlugin.scriptManager.registerFunction("player.getname", (sc, in) -> {
@@ -134,7 +134,7 @@ public class PlayerCommands {
                 return null;
             }
             return op.getName();
-        });
+        }, "string");
         MundusPlugin.scriptManager.registerFunction("player.getuuid", (sc, in) -> {
             Object o = in[0].get(sc);
             if(o instanceof Player) {
@@ -145,34 +145,34 @@ public class PlayerCommands {
                 return null;
             }
             return op.getUniqueId();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("player.getid",
-                (sc, in) -> (double) CommandUtils.getUUID(in[0].get(sc)).hashCode());
+                (sc, in) -> (double) CommandUtils.getUUID(in[0].get(sc)).hashCode(), "number");
         MundusPlugin.scriptManager.registerFunction("player.get",
-                (sc, in) -> Bukkit.getPlayer(CommandUtils.getUUID(in[0].get(sc))));
+                (sc, in) -> Bukkit.getPlayer(CommandUtils.getUUID(in[0].get(sc))), "player");
         MundusPlugin.scriptManager.registerFunction("player.getuuidfromid",
-                (sc, in) -> getUUIDFromId(in[0].getInt(sc)));
+                (sc, in) -> getUUIDFromId(in[0].getInt(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("player.getnamefromid",
-                (sc, in) -> getNameFromId(in[0].getInt(sc)));
+                (sc, in) -> getNameFromId(in[0].getInt(sc)), "string");
         MundusPlugin.scriptManager.registerFunction("player.getip",
-                (sc, in) -> ((Player) in[0].get(sc)).spigot().getRawAddress().toString());
+                (sc, in) -> ((Player) in[0].get(sc)).spigot().getRawAddress().toString(), "string");
         MundusPlugin.scriptManager.registerFunction("player.iscreative",
-                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.CREATIVE);
+                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.CREATIVE, "boolean");
         MundusPlugin.scriptManager.registerFunction("player.isspectator",
-                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.SPECTATOR);
+                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.SPECTATOR, "boolean");
         MundusPlugin.scriptManager.registerFunction("player.issurvival",
-                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.SURVIVAL);
+                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.SURVIVAL, "boolean");
         MundusPlugin.scriptManager.registerFunction("player.isadventure",
-                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.ADVENTURE);
+                (sc, in) -> ((Player) in[0].get(sc)).getGameMode() == GameMode.ADVENTURE, "boolean");
         MundusPlugin.scriptManager.registerConsumer("player.setfly", (sc, in) -> {
             Player p = ((Player) in[0].get(sc));
             boolean b = in[1].getBoolean(sc);
             p.setAllowFlight(b);
         });
         MundusPlugin.scriptManager.registerFunction("player.hasfly",
-                (sc, in) -> ((Player) in[0].get(sc)).getAllowFlight());
+                (sc, in) -> ((Player) in[0].get(sc)).getAllowFlight(), "boolean");
         MundusPlugin.scriptManager.registerFunction("player.isflying",
-                (sc, in) -> ((Player) in[0].get(sc)).isFlying());
+                (sc, in) -> ((Player) in[0].get(sc)).isFlying(), "boolean");
         MundusPlugin.scriptManager.registerConsumer("player.setgamemode", (sc, in) -> {
             ((Player) in[0].get(sc)).setGameMode(GameMode.valueOf(in[1].get(sc).toString()));
         });
@@ -195,11 +195,11 @@ public class PlayerCommands {
                 mode = FluidCollisionMode.ALWAYS;
             }
             return p.getTargetBlockExact(in[1].getInt(sc), mode);
-        });
+        }, "block");
         MundusPlugin.scriptManager.registerFunction("player.gettargetentity", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.getTargetEntity(in[1].getInt(sc));
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerFunction("player.gettargetcitizen", (sc, in) -> {
             Player player = (Player) in[0].get(sc);
             Entity target = player.getTargetEntity(in[1].getInt(sc));
@@ -207,7 +207,7 @@ public class PlayerCommands {
                 return CitizensAPI.getNPCRegistry().getNPC(target);
             }
             return null;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("player.action", (sc, in) -> {
             Component text = (Component) in[1].get(sc);
             CommandUtils.doForGroup(in[0].get(sc), sc, p -> ((Player) p).sendActionBar(text));
@@ -215,19 +215,19 @@ public class PlayerCommands {
         MundusPlugin.scriptManager.registerFunction("player.getspawn", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.getRespawnLocation();
-        });
+        }, "location");
         MundusPlugin.scriptManager.registerFunction("player.getlastdeathlocation", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.getLastDeathLocation();
-        });
+        }, "location");
         MundusPlugin.scriptManager.registerFunction("player.isblocking", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.isBlocking();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("player.getspectatortarget", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.getSpectatorTarget();
-        });
+        }, "entity");
         MundusPlugin.scriptManager.registerConsumer("player.setspectatortarget", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             Entity e = (Entity) in[1].get(sc);
@@ -262,12 +262,12 @@ public class PlayerCommands {
             ((Player) in[0].get(sc)).giveExp(in[1].getInt(sc));
         });
         MundusPlugin.scriptManager.registerFunction("player.getlevel",
-                (sc, in) -> (double) ((Player) in[0].get(sc)).getLevel());
+                (sc, in) -> (double) ((Player) in[0].get(sc)).getLevel(), "number");
         MundusPlugin.scriptManager.registerConsumer("player.setlevel", (sc, in) -> {
             ((Player) in[0].get(sc)).setLevel(in[1].getInt(sc));
         });
         MundusPlugin.scriptManager.registerFunction("player.getexp",
-                (sc, in) -> (double) ((Player) in[0].get(sc)).getExp());
+                (sc, in) -> (double) ((Player) in[0].get(sc)).getExp(), "number");
         MundusPlugin.scriptManager.registerConsumer("player.setexp",
                 (sc, in) -> ((Player) in[0].get(sc)).setExp(in[1].getFloat(sc)));
         MundusPlugin.scriptManager.registerConsumer("player.setexpcooldown",
@@ -286,11 +286,11 @@ public class PlayerCommands {
                     Bukkit.createProfile(CommandUtils.getUUID(in[0].get(sc)), in[1].getString(sc)));
             skull.setItemMeta(meta);
             return skull;
-        });
+        }, "itemstack");
         MundusPlugin.scriptManager.registerFunction("player.getinv",
-                (sc, in) -> ((Player) in[0].get(sc)).getInventory());
+                (sc, in) -> ((Player) in[0].get(sc)).getInventory(), "object");
         MundusPlugin.scriptManager.registerFunction("player.getenderinv",
-                (sc, in) -> ((Player) in[0].get(sc)).getEnderChest());
+                (sc, in) -> ((Player) in[0].get(sc)).getEnderChest(), "object");
         MundusPlugin.scriptManager.registerConsumer("player.setdisplayname", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             p.playerListName((Component) in[1].get(sc));
@@ -338,13 +338,13 @@ public class PlayerCommands {
             p.showPlayer(MundusPlugin.instance, p2);
         });
         MundusPlugin.scriptManager.registerFunction("players.getamount",
-                (sc, in) -> (double) Bukkit.getOnlinePlayers().size());
+                (sc, in) -> (double) Bukkit.getOnlinePlayers().size(), "number");
         MundusPlugin.scriptManager.registerFunction("players.tolist",
-                (sc, in) -> new ArrayList<>(Bukkit.getOnlinePlayers()));
+                (sc, in) -> new ArrayList<>(Bukkit.getOnlinePlayers()), "list");
         MundusPlugin.scriptManager.registerFunction("players.near", (sc, in) -> {
             Location l = (Location) in[0].get(sc);
             return l.getWorld().getNearbyPlayers(l, in[1].getDouble(sc));
-        });
+        }, "set");
         MundusPlugin.scriptManager.registerFunction("player.getnearest", (sc, in) -> {
             Location l = (Location) in[0].get(sc);
             double distance = 10.0;
@@ -359,11 +359,11 @@ public class PlayerCommands {
                 }
             }
             return closest;
-        });
+        }, "player");
         MundusPlugin.scriptManager.registerFunction("player.getping", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.getPing();
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerConsumer("player.setflyspeed", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             p.setFlySpeed(in[1].getFloat(sc));
@@ -375,11 +375,11 @@ public class PlayerCommands {
         MundusPlugin.scriptManager.registerFunction("player.issneaking", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.isSneaking();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("player.issprinting", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             return p.isSprinting();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerConsumer("player.setslot", (sc, in) -> {
             Player p = (Player) in[0].get(sc);
             p.getInventory().setHeldItemSlot(in[1].getInt(sc));

--- a/src/me/hammerle/mp/snuviscript/commands/PlotCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/PlotCommands.java
@@ -11,24 +11,24 @@ public class PlotCommands {
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("legacyplot.get", (sc, in) -> {
             return WorldPlotMap.getPlots((Location) in[0].get(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.check", (sc, in) -> {
             Location l = (Location) in[0].get(sc);
             Player p = (Player) in[1].get(sc);
             int flags = in[2].getInt(sc);
             boolean empty = in[3].getBoolean(sc);
             return WorldPlotMap.canDoSomething(l, p, flags, empty);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("legacyplot.setflags", (sc, in) -> {
             PlotMap.Plot p = (PlotMap.Plot) in[0].get(sc);
             p.setFlag(in[1].getInt(sc), in[2].getBoolean(sc));
         });
         MundusPlugin.scriptManager.registerFunction("legacyplot.hasflags",
-                (sc, in) -> ((PlotMap.Plot) in[0].get(sc)).hasFlags(in[1].getInt(sc)));
+                (sc, in) -> ((PlotMap.Plot) in[0].get(sc)).hasFlags(in[1].getInt(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getflags",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getFlags());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getFlags(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getowners",
-                (sc, in) -> ((PlotMap.Plot) in[0].get(sc)).getOwners());
+                (sc, in) -> ((PlotMap.Plot) in[0].get(sc)).getOwners(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.add", (sc, in) -> {
             Location l1 = (Location) in[0].get(sc);
             Location l2 = (Location) in[1].get(sc);
@@ -39,40 +39,40 @@ public class PlotCommands {
                 return WorldPlotMap.add(l1, l2, in[2].getInt(sc));
             }
             return WorldPlotMap.add(l1, l2);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("legacyplot.remove", (sc, in) -> {
             WorldPlotMap.remove((World) in[1].get(sc), (PlotMap.Plot) in[0].get(sc));
         });
         MundusPlugin.scriptManager.registerFunction("legacyplot.getname",
-                (sc, in) -> ((PlotMap.Plot) in[0].get(sc)).getName());
+                (sc, in) -> ((PlotMap.Plot) in[0].get(sc)).getName(), "object");
         MundusPlugin.scriptManager.registerConsumer("legacyplot.setname", (sc, in) -> {
             ((PlotMap.Plot) in[0].get(sc)).setName(in[1].getString(sc));
         });
         MundusPlugin.scriptManager.registerFunction("legacyplot.getid",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getId());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getId(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.iterator", (sc, in) -> {
             World w = (World) in[0].get(sc);
             if(in.length >= 2) {
                 return WorldPlotMap.getIterator(w, CommandUtils.getUUID(in[1].get(sc)));
             }
             return WorldPlotMap.getIterator(w);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.intersecting",
                 (sc, in) -> WorldPlotMap.getIntersectingPlots((World) in[0].get(sc),
                         in[1].getInt(sc), in[2].getInt(sc), in[3].getInt(sc), in[4].getInt(sc),
-                        in[5].getInt(sc), in[6].getInt(sc)));
+                        in[5].getInt(sc), in[6].getInt(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getminx",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMinX());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMinX(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getminy",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMinY());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMinY(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getminz",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMinZ());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMinZ(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getmaxx",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMaxX());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMaxX(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getmaxy",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMaxY());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMaxY(), "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.getmaxz",
-                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMaxZ());
+                (sc, in) -> (double) ((PlotMap.Plot) in[0].get(sc)).getMaxZ(), "object");
         MundusPlugin.scriptManager.registerConsumer("legacyplot.addblock", (sc, in) -> {
             WorldPlotMap.addInteractBlock((Location) in[0].get(sc));
         });
@@ -81,20 +81,20 @@ public class PlotCommands {
         });
         MundusPlugin.scriptManager.registerFunction("legacyplot.hasblock", (sc, in) -> {
             return WorldPlotMap.hasInteractBlock((Location) in[0].get(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.blockiterator", (sc, in) -> {
             World w = (World) in[0].get(sc);
             return WorldPlotMap.getBlockIterator(w);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.position.getx", (sc, in) -> {
             return (double) ((PlotMap.Position) in[0].get(sc)).getX();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.position.gety", (sc, in) -> {
             return (double) ((PlotMap.Position) in[0].get(sc)).getY();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("legacyplot.position.getz", (sc, in) -> {
             return (double) ((PlotMap.Position) in[0].get(sc)).getZ();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("legacyplot.saveplots", (sc, in) -> {
             WorldPlotMap.savePlots((World) in[0].get(sc));
         });

--- a/src/me/hammerle/mp/snuviscript/commands/ReadCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ReadCommands.java
@@ -32,7 +32,7 @@ public class ReadCommands {
             } catch(Exception ex) {
                 return null;
             }
-        });
+        }, "itemstack");
         MundusPlugin.scriptManager.registerFunction("read.uuid", (sc, in) -> {
             String s = in[0].getString(sc);
             try {
@@ -40,7 +40,7 @@ public class ReadCommands {
             } catch(Exception ex) {
                 return null;
             }
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("read.slot", (sc, in) -> {
             String s = in[0].getString(sc);
             try {
@@ -48,7 +48,7 @@ public class ReadCommands {
             } catch(Exception ex) {
                 return null;
             }
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("read.blockdata", (sc, in) -> {
             String s = in[0].getString(sc);
             try {
@@ -56,6 +56,6 @@ public class ReadCommands {
             } catch(Exception ex) {
                 return null;
             }
-        });
+        }, "object");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/ScriptCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ScriptCommands.java
@@ -23,20 +23,20 @@ public class ScriptCommands {
                 names[i] = in[i].getString(sc);
             }
             return MundusPlugin.startLocalScript(null, names);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("script.start", (sc, in) -> {
             String[] names = new String[in.length];
             for(int i = 0; i < in.length; i++) {
                 names[i] = in[i].getString(sc);
             }
             return MundusPlugin.startGlobalScript(null, names);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("script.startnamed", (sc, in) -> {
             String[] names = new String[in.length - 1];
             for(int i = 0; i < names.length; i++) {
                 names[i] = in[i + 1].getString(sc);
             }
             return MundusPlugin.startGlobalScript(in[0].getString(sc), names);
-        });
+        }, "object");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/SoundCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/SoundCommands.java
@@ -16,11 +16,11 @@ public class SoundCommands {
                     .map(f -> "minecraft:" + f.toString().toLowerCase())
                     .sorted()
                     .collect(Collectors.toList());
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("sound.get",
-                (sc, in) -> Registry.SOUNDS.get(NamespacedKey.fromString(in[0].getString(sc))));
+                (sc, in) -> Registry.SOUNDS.get(NamespacedKey.fromString(in[0].getString(sc))), "object");
         MundusPlugin.scriptManager.registerFunction("sound.getcategory",
-                (sc, in) -> SoundCategory.valueOf(in[0].getString(sc)));
+                (sc, in) -> SoundCategory.valueOf(in[0].getString(sc)), "object");
         MundusPlugin.scriptManager.registerConsumer("sound.spawn", (sc, in) -> {
             Location l = (Location) in[0].get(sc);
             float volume = in.length >= 4 ? in[3].getFloat(sc) : 1.0f;

--- a/src/me/hammerle/mp/snuviscript/commands/TableCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/TableCommands.java
@@ -11,23 +11,23 @@ public class TableCommands {
                 widths[i] = in[i + 1].getInt(sc);
             }
             return new Table(in[0].getString(sc), widths);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("table.getstart", (sc, in) -> {
             return ((Table) in[0].get(sc)).getStart();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("table.getmiddle", (sc, in) -> {
             return ((Table) in[0].get(sc)).getMiddle();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("table.getend", (sc, in) -> {
             return ((Table) in[0].get(sc)).getEnd();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("table.get", (sc, in) -> {
             String[] columns = new String[in.length - 1];
             for(int i = 0; i < columns.length; i++) {
                 columns[i] = in[i + 1].getString(sc);
             }
             return ((Table) in[0].get(sc)).get(columns);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("table.setsize", (sc, in) -> {
             Table.addSizeMapping(in[0].getString(sc).charAt(0), in[1].getInt(sc));
         });

--- a/src/me/hammerle/mp/snuviscript/commands/TextCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/TextCommands.java
@@ -18,7 +18,7 @@ public class TextCommands {
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("string.text",
                 (sc, in) -> PlainTextComponentSerializer.plainText()
-                        .serialize((Component) in[0].get(sc)));
+                        .serialize((Component) in[0].get(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("string.item", (sc, in) -> {
             ItemStack stack = (ItemStack) in[0].get(sc);
             if(stack == null || stack.getType() == Material.AIR) {
@@ -26,52 +26,52 @@ public class TextCommands {
             }
             ReadWriteNBT nbt = NBT.itemStackToNBT(stack);
             return nbt.toString();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("string.entity", (sc, in) -> {
             Entity e = (Entity) in[0].get(sc);
             ReadWriteNBT nbt = NBT.createNBTObject();
             NBT.get(e, nbt::mergeCompound);
             return nbt.toString();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("string.blockdata",
-                (sc, in) -> ((BlockData) in[0].get(sc)).getAsString());
+                (sc, in) -> ((BlockData) in[0].get(sc)).getAsString(), "object");
 
         MundusPlugin.scriptManager.registerFunction("text.new",
-                (sc, in) -> Component.text(in[0].getString(sc)));
+                (sc, in) -> Component.text(in[0].getString(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("text.color", (sc, in) -> {
             Component c = (Component) in[0].get(sc);
             return c.color(TextColor.color(in[1].getInt(sc), in[2].getInt(sc), in[3].getInt(sc)));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("text.click", (sc, in) -> {
             Component c = (Component) in[0].get(sc);
             return c.clickEvent(ClickEvent.runCommand(in[1].getString(sc)));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("text.suggest", (sc, in) -> {
             Component c = (Component) in[0].get(sc);
             return c.clickEvent(ClickEvent.suggestCommand(in[1].getString(sc)));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("text.item", (sc, in) -> {
             Component c = (Component) in[0].get(sc);
             return c.hoverEvent(((ItemStack) in[1].get(sc)).asHoverEvent());
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("text.hover", (sc, in) -> {
             Component c = (Component) in[0].get(sc);
             return c.hoverEvent(HoverEvent.showText((Component) in[1].get(sc)));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("text.link", (sc, in) -> {
             Component c = (Component) in[0].get(sc);
             return c.clickEvent(ClickEvent.openUrl(in[1].getString(sc)));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("text.clipboard", (sc, in) -> {
             Component c = (Component) in[0].get(sc);
             return c.clickEvent(ClickEvent.copyToClipboard(in[1].getString(sc)));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("text.merge", (sc, in) -> {
             TextComponent.Builder c = Component.text();
             for(int i = 0; i < in.length; i++) {
                 c.append((Component) in[i].get(sc));
             }
             return c.build();
-        });
+        }, "object");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/WorldCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/WorldCommands.java
@@ -15,11 +15,11 @@ public class WorldCommands {
     @SuppressWarnings("")
     public static void registerFunctions() {
         MundusPlugin.scriptManager.registerFunction("world.getplayers",
-                (sc, in) -> new ArrayList<>(((World) in[0].get(sc)).getPlayers()));
+                (sc, in) -> new ArrayList<>(((World) in[0].get(sc)).getPlayers()), "list");
         MundusPlugin.scriptManager.registerFunction("world.get",
-                (sc, in) -> Bukkit.getServer().getWorld(in[0].getString(sc)));
+                (sc, in) -> Bukkit.getServer().getWorld(in[0].getString(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("world.getname",
-                (sc, in) -> ((World) in[0].get(sc)).getName());
+                (sc, in) -> ((World) in[0].get(sc)).getName(), "string");
         MundusPlugin.scriptManager.registerConsumer("world.setdifficulty", (sc, in) -> {
             ((World) in[0].get(sc)).setDifficulty(Difficulty.valueOf(in[1].getString(sc)));
         });
@@ -28,17 +28,17 @@ public class WorldCommands {
             l.getWorld().setSpawnLocation(l);
         });
         MundusPlugin.scriptManager.registerFunction("world.getspawn",
-                (sc, in) -> ((World) in[0].get(sc)).getSpawnLocation());
+                (sc, in) -> ((World) in[0].get(sc)).getSpawnLocation(), "location");
         MundusPlugin.scriptManager.registerFunction("world.getall",
-                (sc, in) -> new ArrayList<>(Bukkit.getWorlds()));
+                (sc, in) -> new ArrayList<>(Bukkit.getWorlds()), "list");
         MundusPlugin.scriptManager.registerConsumer("world.settime",
                 (sc, in) -> ((World) in[0].get(sc)).setTime(in[1].getLong(sc)));
         MundusPlugin.scriptManager.registerFunction("world.gettime",
-                (sc, in) -> (double) ((World) in[0].get(sc)).getTime());
+                (sc, in) -> (double) ((World) in[0].get(sc)).getTime(), "number");
         MundusPlugin.scriptManager.registerFunction("world.hasrain",
-                (sc, in) -> ((World) in[0].get(sc)).hasStorm());
+                (sc, in) -> ((World) in[0].get(sc)).hasStorm(), "boolean");
         MundusPlugin.scriptManager.registerFunction("world.hasthunder",
-                (sc, in) -> ((World) in[0].get(sc)).isThundering());
+                (sc, in) -> ((World) in[0].get(sc)).isThundering(), "boolean");
         MundusPlugin.scriptManager.registerConsumer("world.clearweather", (sc, in) -> {
             World w = (World) in[0].get(sc);
             w.setStorm(false);
@@ -56,12 +56,12 @@ public class WorldCommands {
             w.setThunderDuration(in[1].getInt(sc));
         });
         MundusPlugin.scriptManager.registerFunction("world.getentities",
-                (sc, in) -> new ArrayList<>(((World) in[0].get(sc)).getEntities()));
+                (sc, in) -> new ArrayList<>(((World) in[0].get(sc)).getEntities()), "list");
         MundusPlugin.scriptManager.registerFunction("world.load", (sc, in) -> {
             World w = Bukkit.createWorld(WorldCreator.name(in[0].getString(sc)));
             WorldPlotMap.read(w.getName());
             return w;
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("world.setborder", (sc, in) -> {
             World w = (World) in[0].get(sc);
             Location l = (Location) in[1].get(sc);
@@ -70,21 +70,21 @@ public class WorldCommands {
             border.setSize(in[2].getInt(sc));
         });
         MundusPlugin.scriptManager.registerFunction("world.unload",
-                (sc, in) -> Bukkit.unloadWorld((World) in[0].get(sc), true));
+                (sc, in) -> Bukkit.unloadWorld((World) in[0].get(sc), true), "boolean");
         MundusPlugin.scriptManager.registerFunction("world.getloadedchunks", (sc, in) -> {
             return ((World) in[0].get(sc)).getLoadedChunks();
-        });
+        }, "array");
         MundusPlugin.scriptManager.registerFunction("world.unloadchunk", (sc, in) -> {
             return ((Chunk) in[0].get(sc)).unload();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("world.isforceloadedchunk", (sc, in) -> {
             return ((Chunk) in[0].get(sc)).isForceLoaded();
-        });
+        }, "boolean");
         MundusPlugin.scriptManager.registerFunction("world.getchunkx", (sc, in) -> {
             return (double) ((Chunk) in[0].get(sc)).getX();
-        });
+        }, "number");
         MundusPlugin.scriptManager.registerFunction("world.getchunkz", (sc, in) -> {
             return (double) ((Chunk) in[0].get(sc)).getZ();
-        });
+        }, "number");
     }
 }

--- a/src/me/hammerle/mp/snuviscript/commands/WorldGuardCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/WorldGuardCommands.java
@@ -42,24 +42,24 @@ public class WorldGuardCommands {
         registerFlags();
         MundusPlugin.scriptManager.registerFunction("plot.get", (sc, in) -> {
             return getRegions((Location) in[0].get(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.check", (sc, in) -> {
             Location l = (Location) in[0].get(sc);
             Player p = (Player) in[1].get(sc);
             int flags = in[2].getInt(sc);
             boolean empty = in[3].getBoolean(sc);
             return canDoSomething(l, p, flags, empty);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("plot.setflags", (sc, in) -> {
             ProtectedRegion region = (ProtectedRegion) in[0].get(sc);
             setFlag(region, in[1].getInt(sc), in[2].getBoolean(sc));
         });
         MundusPlugin.scriptManager.registerFunction("plot.hasflags", (sc, in) -> {
             return hasFlags((ProtectedRegion) in[0].get(sc), in[1].getInt(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.getflags", (sc, in) -> {
             return (double) getFlags((ProtectedRegion) in[0].get(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("plot.setflagsmask", (sc, in) -> {
             ProtectedRegion r = (ProtectedRegion) in[0].get(sc);
             r.setFlag(flagsFlag, in[1].getInt(sc));
@@ -82,7 +82,7 @@ public class WorldGuardCommands {
         });
         MundusPlugin.scriptManager.registerFunction("plot.getowners", (sc, in) -> {
             return new ArrayList<>(((ProtectedRegion) in[0].get(sc)).getOwners().getUniqueIds());
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.add", (sc, in) -> {
             Location l1 = (Location) in[0].get(sc);
             Location l2 = (Location) in[1].get(sc);
@@ -93,40 +93,40 @@ public class WorldGuardCommands {
                 return addRegion(l1, l2, in[2].getInt(sc));
             }
             return addRegion(l1, l2, null);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("plot.remove", (sc, in) -> {
             removeRegion((World) in[1].get(sc), (ProtectedRegion) in[0].get(sc));
         });
         MundusPlugin.scriptManager.registerFunction("plot.getname",
-                (sc, in) -> getName((ProtectedRegion) in[0].get(sc)));
+                (sc, in) -> getName((ProtectedRegion) in[0].get(sc)), "object");
         MundusPlugin.scriptManager.registerConsumer("plot.setname", (sc, in) -> {
             ((ProtectedRegion) in[0].get(sc)).setFlag(nameFlag, in[1].getString(sc));
         });
         MundusPlugin.scriptManager.registerFunction("plot.getid",
-                (sc, in) -> (double) getId((ProtectedRegion) in[0].get(sc)));
+                (sc, in) -> (double) getId((ProtectedRegion) in[0].get(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("plot.iterator", (sc, in) -> {
             World w = (World) in[0].get(sc);
             if(in.length >= 2) {
                 return getIterator(w, CommandUtils.getUUID(in[1].get(sc)));
             }
             return getIterator(w);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.intersecting",
                 (sc, in) -> getIntersectingPlots((World) in[0].get(sc), in[1].getInt(sc),
                         in[2].getInt(sc), in[3].getInt(sc), in[4].getInt(sc), in[5].getInt(sc),
-                        in[6].getInt(sc)));
+                        in[6].getInt(sc)), "object");
         MundusPlugin.scriptManager.registerFunction("plot.getminx",
-                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMinimumPoint().x());
+                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMinimumPoint().x(), "object");
         MundusPlugin.scriptManager.registerFunction("plot.getminy",
-                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMinimumPoint().y());
+                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMinimumPoint().y(), "object");
         MundusPlugin.scriptManager.registerFunction("plot.getminz",
-                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMinimumPoint().z());
+                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMinimumPoint().z(), "object");
         MundusPlugin.scriptManager.registerFunction("plot.getmaxx",
-                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMaximumPoint().x());
+                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMaximumPoint().x(), "object");
         MundusPlugin.scriptManager.registerFunction("plot.getmaxy",
-                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMaximumPoint().y());
+                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMaximumPoint().y(), "object");
         MundusPlugin.scriptManager.registerFunction("plot.getmaxz",
-                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMaximumPoint().z());
+                (sc, in) -> (double) ((ProtectedRegion) in[0].get(sc)).getMaximumPoint().z(), "object");
         MundusPlugin.scriptManager.registerConsumer("plot.addblock", (sc, in) -> {
             addInteractBlock((Location) in[0].get(sc));
         });
@@ -135,20 +135,20 @@ public class WorldGuardCommands {
         });
         MundusPlugin.scriptManager.registerFunction("plot.hasblock", (sc, in) -> {
             return hasInteractBlock((Location) in[0].get(sc));
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.blockiterator", (sc, in) -> {
             World w = (World) in[0].get(sc);
             return getBlockIterator(w);
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.position.getx", (sc, in) -> {
             return (double) ((PlotMap.Position) in[0].get(sc)).getX();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.position.gety", (sc, in) -> {
             return (double) ((PlotMap.Position) in[0].get(sc)).getY();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerFunction("plot.position.getz", (sc, in) -> {
             return (double) ((PlotMap.Position) in[0].get(sc)).getZ();
-        });
+        }, "object");
         MundusPlugin.scriptManager.registerConsumer("plot.saveplots", (sc, in) -> {
             savePlots((World) in[0].get(sc));
         });


### PR DESCRIPTION
### Motivation

- Make the scripting metadata more precise so tooling and callers can rely on concrete return types instead of broad `object` fallbacks.
- Apply Snuvi/Bukkit semantics (e.g. `material.get` returns a material, `material.issolid` returns a boolean) across the command registration surface.
- Fix dynamic registrations where the return type was omitted (notably the living-attribute getters) so all `registerFunction(...)` calls include explicit metadata.

### Description

- Updated `registerFunction(...)` invocations across many command modules to include explicit return-type strings, with focused refinements in `ItemCommands`, `EntityCommands`, and `LivingCommands` and matching adjustments in other command classes.
- Representative mappings added: `material.get -> "material"`, `material.issolid -> "boolean"`, `item.new -> "itemstack"`, `item.getname -> "text"`, `item.getlore -> "list"`, `entity.getlocation -> "location"`, `entity.get -> "entity"`, `entity.getlook/getmotion -> "array"`, `entity.frame.getitem -> "itemstack"`, `slime.getsize -> "number"`, `living.gethealth -> "number"`, and dynamic attribute getters `registerFunction(getCmd, ...) -> "number"`.
- Kept `"object"` as a conservative fallback where a more specific mapping was ambiguous and left runtime logic unchanged, only adding/adjusting the trailing type argument to `MundusPlugin.scriptManager.registerFunction(...)`.

### Testing

- Verified with a local parser script that scans `src/me/hammerle/mp/snuviscript/commands` and confirmed every `registerFunction(...)` now ends with an explicit type string (`missing 0`).
- Retried the documentation URL `https://mundus-crassus.de/snuvi_minecraft` but the environment returned `403 Forbidden`, so refinements were based on command semantics and the Bukkit API.
- Attempted `ant -q compile` but `ant` is not installed in this environment, so no compile/run tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a849ba7c8332bb2591643d137269)