### PR TITLE
Register Minecraft script types and set read.player return type to Player

### DIFF
--- a/src/me/hammerle/mp/snuviscript/ScriptTypeRegistration.java
+++ b/src/me/hammerle/mp/snuviscript/ScriptTypeRegistration.java
@@ -3,8 +3,10 @@ package me.hammerle.mp.snuviscript;
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import me.hammerle.mp.MundusPlugin;
 import me.hammerle.snuviscript.inputprovider.ScriptTypeRegistry;
 
@@ -12,9 +14,11 @@ public final class ScriptTypeRegistration {
     private ScriptTypeRegistration() {}
 
     public static void registerMinecraftTypes() {
-        //registerType("entity", Entity.class::isInstance);
-        //registerType("living", LivingEntity.class::isInstance, "entity");
-        //registerType("player", Player.class::isInstance, "living", "entity");
+        registerType("Entity", Entity.class::isInstance);
+        registerType("LivingEntity", LivingEntity.class::isInstance, "Entity");
+        registerType("Player", Player.class::isInstance, "LivingEntity", "Entity");
+        registerType("ItemStack", ItemStack.class::isInstance);
+        registerType("ItemEntity", Item.class::isInstance, "Entity");
     }
 
     private static void registerType(String name, Predicate<Object> check, String... parents) {

--- a/src/me/hammerle/mp/snuviscript/commands/ReadCommands.java
+++ b/src/me/hammerle/mp/snuviscript/commands/ReadCommands.java
@@ -20,7 +20,7 @@ public class ReadCommands {
                 }
             }
             return null;
-        });
+        }, "Player");
         MundusPlugin.scriptManager.registerFunction("read.item", (sc, in) -> {
             String s = in[0].getString(sc);
             if(s.contains("minecraft:air")) {


### PR DESCRIPTION
### Motivation
- Ensure the scripting system has explicit Minecraft type registrations available and make the return type of the `read.player` helper explicit so the script runtime can treat results as `Player` objects.

### Description
- Re-enabled and updated Minecraft script type registration in `ScriptTypeRegistration`: register `Entity`, `LivingEntity`, `Player`, `ItemStack` and `ItemEntity` with the script type registry and preserve parent relationships when supported by the API.
- Annotated the `read.player` function registration in `ReadCommands` by adding the return type parameter `"Player"` while leaving the lookup logic unchanged.

### Testing
- Attempted to run `ant -q compile`, but the command failed in this environment because `ant` is not installed. No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ee532d54833295425daa9bc1cdb7)